### PR TITLE
Add checklists for reviewers

### DIFF
--- a/app/lib/actions.rb
+++ b/app/lib/actions.rb
@@ -7,7 +7,7 @@ module Actions
 
   # Update the body of the issue between marks
   def update_body(start_mark, end_mark, new_text)
-    new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/i, "#{start_mark}#{new_text}#{end_mark}")
+    new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{new_text}#{end_mark}")
     update_issue({ body: new_body })
   end
 
@@ -20,9 +20,9 @@ module Actions
   # Remove a block of text from the body of the issue optionally including start/end marks
   def delete_from_body(start_mark, end_mark, delete_marks=false)
     if delete_marks
-      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/i, "")
+      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "")
     else
-      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/i, "#{start_mark}#{end_mark}")
+      new_body = issue_body.gsub(/#{start_mark}.*#{end_mark}/im, "#{start_mark}#{end_mark}")
     end
     update_issue({ body: new_body })
   end
@@ -42,7 +42,7 @@ module Actions
 
   def read_from_body(start_mark, end_mark)
     text = ""
-    issue_body.match(/#{start_mark}(.*)#{end_mark}/i) do |m|
+    issue_body.match(/#{start_mark}(.*)#{end_mark}/im) do |m|
       text = m[1]
     end
     text.strip

--- a/app/lib/responder_registry.rb
+++ b/app/lib/responder_registry.rb
@@ -4,21 +4,22 @@ Dir["#{File.expand_path '../../responders', __FILE__}/**/*.rb"].sort.each { |f| 
 class ResponderRegistry
 
   RESPONDER_MAPPING = {
-    "help"                => HelpResponder,
-    "hello"               => HelloResponder,
-    "assign_reviewer_n"   => AssignReviewerNResponder,
-    "remove_reviewer_n"   => RemoveReviewerNResponder,
-    "assign_editor"       => AssignEditorResponder,
-    "remove_editor"       => RemoveEditorResponder,
-    "invite"              => InviteResponder,
-    "set_value"           => SetValueResponder,
-    "add_remove_assignee" => AddAndRemoveAssigneeResponder,
-    "label_command"       => LabelCommandResponder,
-    "thanks"              => ThanksResponder,
-    "welcome"             => WelcomeResponder,
-    "welcome_template"    => WelcomeTemplateResponder,
-    "close_issue_command" => CloseIssueCommandResponder,
-    "external_service"    => ExternalServiceResponder,
+    "help"                 => HelpResponder,
+    "hello"                => HelloResponder,
+    "assign_reviewer_n"    => AssignReviewerNResponder,
+    "remove_reviewer_n"    => RemoveReviewerNResponder,
+    "assign_editor"        => AssignEditorResponder,
+    "remove_editor"        => RemoveEditorResponder,
+    "invite"               => InviteResponder,
+    "set_value"            => SetValueResponder,
+    "add_remove_assignee"  => AddAndRemoveAssigneeResponder,
+    "label_command"        => LabelCommandResponder,
+    "thanks"               => ThanksResponder,
+    "welcome"              => WelcomeResponder,
+    "welcome_template"     => WelcomeTemplateResponder,
+    "close_issue_command"  => CloseIssueCommandResponder,
+    "external_service"     => ExternalServiceResponder,
+    "add_remove_checklist" => AddAndRemoveUserChecklistResponder,
   }
 
   attr_accessor :responders

--- a/app/responders/add_and_remove_user_checklist.rb
+++ b/app/responders/add_and_remove_user_checklist.rb
@@ -1,0 +1,60 @@
+require_relative '../lib/responder'
+
+class AddAndRemoveUserChecklistResponder < Responder
+
+  def define_listening
+    required_params :template_file
+
+    @event_action = "issue_comment.created"
+    @event_regex = /\A@#{@bot_name} (add|remove) checklist for (\S+)\s*\z/i
+  end
+
+  def process_message(message)
+    add_or_remove = @match_data[1].downcase
+    user = @match_data[2]
+
+    @mark = "<!--checklist-for-#{user}-->"
+    @end_mark = "<!--end-checklist-for-#{user}-->"
+
+    @previous = read_from_body(@mark, @end_mark)
+
+    if add_or_remove == "add"
+      add_checklist user
+    elsif add_or_remove == "remove"
+      remove_checklist user
+    end
+  end
+
+  def add_checklist(user)
+    if @previous.empty?
+      checklist = "\n" + @mark +
+                  "\n" + "## Review checklist for " + user +
+                  "\n" + render_external_template(template_file, locals) +
+                  "\n" + @end_mark+ "\n"
+
+      append_to_body checklist
+      respond("Checklist added for #{user}")
+    else
+      respond("There is already a checklist for #{user}")
+    end
+  end
+
+  def remove_checklist(user)
+    if @previous.empty?
+      respond("There is not a checklist for #{user}")
+    else
+      delete_from_body(@mark, @end_mark, true)
+      respond("Checklist for #{user} removed")
+    end
+  end
+
+  def description
+    ["Add review checklist for a user",
+     "Remove the checklist for a user"]
+  end
+
+  def example_invocation
+    ["@#{@bot_name} add checklist for @username",
+     "@#{@bot_name} remove checklist for @username"]
+  end
+end

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -82,3 +82,9 @@ buffy:
               animal_type: cat
               amount: 1
           template_file: cats.md
+    add_remove_checklist:
+      only: editors
+      template_file: reviewer_checklist.md
+      data_from_issue:
+            - target-repository
+            - author-handle

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -43,7 +43,7 @@ describe "Actions" do
 
   describe "#delete_from_body" do
     before do
-      issue_body = "Intro <before> Here! <after> Final"
+      issue_body = "Intro <before> Here!\n <after> Final"
       allow(subject).to receive(:issue_body).and_return(issue_body)
     end
 

--- a/spec/responders/add_and_remove_user_checklist_responder_spec.rb
+++ b/spec/responders/add_and_remove_user_checklist_responder_spec.rb
@@ -1,0 +1,86 @@
+require_relative "../spec_helper.rb"
+
+describe AddAndRemoveUserChecklistResponder do
+
+  subject do
+    described_class
+  end
+
+  before do
+    @responder = subject.new({bot_github_user: 'botsci'}, {template_file: 'checklist.md'})
+  end
+
+  describe "listening" do
+    it "should listen to new comments" do
+      expect(@responder.event_action).to eq("issue_comment.created")
+    end
+
+    it "should define regex" do
+      expect(@responder.event_regex).to match("@botsci add checklist for @arfon")
+      expect(@responder.event_regex).to match("@botsci remove checklist for @arfon   \r\n")
+      expect(@responder.event_regex).to_not match("remove checklist for @arfon")
+      expect(@responder.event_regex).to_not match("@botsci add checklist for @arfon and others")
+      expect(@responder.event_regex).to_not match("@botsci add checklist for ")
+    end
+  end
+
+  describe "#process_message" do
+    before do
+      @responder.context = OpenStruct.new(repo: "openjournals/joss")
+      @responder.context = OpenStruct.new(issue_id: 5,
+                                          repo: "openjournals/buffy",
+                                          sender: "user33",
+                                          issue_body: "Test Review\n\n ... description ..." +
+                                                      "<!--checklist-for-@xuanxu-->\n " +
+                                                      "[ ] this \n [ ] that \n" +
+                                                      "<!--end-checklist-for-@xuanxu-->")
+      disable_github_calls_for(@responder)
+    end
+
+    context "adding a checklist" do
+      it "should add user checklist if not already present" do
+        msg = "@botsci add checklist for @arfon"
+        @responder.match_data = @responder.event_regex.match(msg)
+
+        expected_locals = { issue_id: 5, bot_name: "botsci", repo: "openjournals/buffy", sender: "user33" }
+        expected_checklist = "\n<!--checklist-for-@arfon-->" +
+                             "\n## Review checklist for @arfon" +
+                             "\n[] A" +
+                             "\n<!--end-checklist-for-@arfon-->\n"
+
+        expect(@responder).to receive(:render_external_template).with("checklist.md", expected_locals).and_return("[] A")
+        expect(@responder).to receive(:append_to_body).with(expected_checklist)
+        expect(@responder).to receive(:respond).with("Checklist added for @arfon")
+        @responder.process_message(@msg)
+      end
+
+      it "should not add user checklist if already present" do
+        msg = "@botsci add checklist for @xuanxu"
+        @responder.match_data = @responder.event_regex.match(msg)
+
+        expect(@responder).to receive(:respond).with("There is already a checklist for @xuanxu")
+        @responder.process_message(@msg)
+      end
+    end
+
+    context "removing a checklist" do
+      it "should remove user checklist if present" do
+        msg = "@botsci remove checklist for @xuanxu"
+        @responder.match_data = @responder.event_regex.match(msg)
+
+        expected_mark = "<!--checklist-for-@xuanxu-->"
+        expected_end_mark = "<!--end-checklist-for-@xuanxu-->"
+        expect(@responder).to receive(:delete_from_body).with(expected_mark, expected_end_mark, true)
+        expect(@responder).to receive(:respond).with("Checklist for @xuanxu removed")
+        @responder.process_message(@msg)
+      end
+
+      it "should not remove user checklist if not present" do
+        msg = "@botsci remove checklist for @arfon"
+        @responder.match_data = @responder.event_regex.match(msg)
+        expect(@responder).to receive(:respond).with("There is not a checklist for @arfon")
+        @responder.process_message(@msg)
+      end
+    end
+  end
+end

--- a/spec/support/responder_params.rb
+++ b/spec/support/responder_params.rb
@@ -7,6 +7,7 @@ module ResponderParams
       CloseIssueCommandResponder => { command: "close_command_#{n}", labels: ["label_#{n}"] },
       WelcomeTemplateResponder => { template_file: "test.md" },
       ExternalServiceResponder => { name: "external_service_#{n}", command: "bot call service #{n}", url: "https://github.com/openjournals"},
+      AddAndRemoveUserChecklistResponder => { template_file: "checklist.md" },
     }
 
     params_by_responder[responder_class] || {}


### PR DESCRIPTION
This PR adds a responder to manage checklists. 
It adds commands to add and remove a checklist for a specific user at the end of the body of an issue.