### PR TITLE
Conditions

### DIFF
--- a/app/lib/github_webhook_parser.rb
+++ b/app/lib/github_webhook_parser.rb
@@ -32,6 +32,7 @@ module GitHubWebhookParser
     end
 
     @issue_id = @payload.dig('issue', 'number')
+    @issue_title = @payload.dig('issue', 'title')
     @issue_body = @payload.dig('issue', 'body')
     @repo = @payload.dig('repository', 'full_name')
 
@@ -39,6 +40,7 @@ module GitHubWebhookParser
       action: @action,
       event: @event,
       issue_id: @issue_id,
+      issue_title: @issue_title,
       issue_body: @issue_body,
       message: @message,
       repo: @repo,

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -24,6 +24,8 @@ buffy:
           template_file: editors.md
     assign_reviewer_n:
       only: editors
+      if:
+        role_assigned: editor
     remove_reviewer_n:
       only: editors
       no_reviewer_text: "TBD"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,8 @@ For security reasons is a good practice to load the secret values from your envi
 
  The responders node lists all the responders that will be available. The key for each entry is the name of the responder and nested under it the configuration options for that responder are declared.
 
+### Common options
+
  All the responders share some options available to all of them. They can also have their own particular configurable parameters (see [docs for each responder](./available_responders)). The common parameters are:
 
 <dl>
@@ -123,7 +125,7 @@ For security reasons is a good practice to load the secret values from your envi
   <dd>This setting is used to impose conditions on the responder. It can include several options:
 
 ```eval_rst
-:title: *<String>* or *<Regular Expresion>* Responder will run only if issue title matches this.
+:title: *<String>* or *<Regular Expresion>* Responder will run only if issue' title matches this.
 :body: *<String>* or *<Regular Expresion>* Responder will run only if the body of the issue matches this.
 :value: *<String>* Responder will run only if there is a value for this in the issue (marked with HTML comments).
 :role_assigned: *<String>* Responder will be run only if there is a username assigned for the specified value.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,29 @@ For security reasons is a good practice to load the secret values from your envi
   ```
 
   </dd>
+
+  <dt>if</dt>
+  <dd>This setting is used to impose conditions on the responder. It can include several options:
+
+```eval_rst
+:title: *<String>* or *<Regular Expresion>* Responder will run only if issue title matches this.
+:body: *<String>* or *<Regular Expresion>* Responder will run only if the body of the issue matches this.
+:value: *<String>* Responder will run only if there is a value for this in the issue (marked with HTML comments).
+:role_assigned: *<String>* Responder will be run only if there is a username assigned for the specified value.
+```
+
+  Example:
+
+  ```yaml
+    assign_reviewer:
+      if:
+        role_assigned: editor
+    start_review:
+      if:
+        title: "^\\[PRE-REVIEW\\]"
+  ```
+  </dd>
+
 </dl>
 
 Several responders also allow [adding or removing labels](./labeling).

--- a/spec/responder_spec.rb
+++ b/spec/responder_spec.rb
@@ -68,6 +68,113 @@ describe Responder do
     end
   end
 
+  describe "#meet_conditions?" do
+    before do
+      @responder = Responder.new({}, {})
+      @responder.context = OpenStruct.new(issue_title: "[REVIEW] Software review",
+                                          issue_body: "Test Review\n\n ... description ...\n" +
+                                                      "<!--editor-->@editor<!--end-editor-->\n" +
+                                                      "<!--editor-2-->L.B.<!--end-editor-2-->\n" +
+                                                      "<!--author--><!--end-author-->\n")
+      disable_github_calls_for(@responder)
+      @context = OpenStruct.new({ if: { title: "[REVIEW]", body:"<!--REVIEW-->", value: "editor" } })
+    end
+
+    it "should be true if there is not conditions (via :if setting)" do
+      @responder.params = {}
+      expect(@responder.meet_conditions?).to be_truthy
+
+      @responder.params = { if: {}}
+      expect(@responder.meet_conditions?).to be_truthy
+
+      @responder.params = { if: {title: nil, body: nil, value: nil}}
+      expect(@responder.meet_conditions?).to be_truthy
+
+      @responder.params = { if: {title: "", body: "", value: ""}}
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+
+    it "should be false if title condition is not met" do
+      @responder.params = { if: {title: "PRE-REVIEW"} }
+      expect(@responder).to receive(:respond).with("I can't do that in this kind of issue")
+      expect(@responder.meet_conditions?).to be_falsy
+    end
+
+    it "should be false if body condition is not met" do
+      @responder.params = { if: {body: "ABCDEFG"} }
+      expect(@responder).to receive(:respond).with("I can't do that. Data in the body of the issue is incorrect")
+      expect(@responder.meet_conditions?).to be_falsy
+    end
+
+    it "should be false if value condition is not met" do
+      @responder.params = { if: {value: "author"} }
+      expect(@responder).to receive(:respond).with("That can't be done if there is no author")
+      expect(@responder.meet_conditions?).to be_falsy
+
+      @responder.params = { if: {value: "reviewers"} }
+      expect(@responder).to receive(:respond).with("That can't be done if there is no reviewers")
+      expect(@responder.meet_conditions?).to be_falsy
+    end
+
+    it "should be false if role_assigned condition is not met" do
+      @responder.params = { if: {role_assigned: "editor-2"} } #no username
+      expect(@responder).to receive(:respond).with("That can't be done if there is no editor-2 assigned")
+      expect(@responder.meet_conditions?).to be_falsy
+
+      @responder.params = { if: {role_assigned: "author"} } # empty
+      expect(@responder).to receive(:respond).with("That can't be done if there is no author assigned")
+      expect(@responder.meet_conditions?).to be_falsy
+
+      @responder.params = { if: {role_assigned: "reviewers"} } #no present
+      expect(@responder).to receive(:respond).with("That can't be done if there is no reviewers assigned")
+      expect(@responder.meet_conditions?).to be_falsy
+    end
+
+    it "should be false if any condition is not met" do
+      @responder.params = { if: {title: "REVIEW", body: "^Test Review", value: "author"} }
+      expect(@responder).to receive(:respond)
+      expect(@responder.meet_conditions?).to be_falsey
+    end
+
+    it "should be true if title condition is met" do
+      @responder.params = { if: {title: "^\\[REVIEW\\]"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+
+      @responder.params = { if: {title: "REVIEW"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+
+    it "should be true if body condition is met" do
+      @responder.params = { if: {body: "^Test Review"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+
+      @responder.params = { if: {body: "description"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+
+    it "should be true if value condition is met" do
+      @responder.params = { if: {value: "editor-2"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+
+    it "should be true if role_assigned condition is met" do
+      @responder.params = { if: {role_assigned: "editor"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+
+    it "should be true only if all conditions are met" do
+      @responder.params = { if: {title: "REVIEW", body: "^Test Review", value: "editor-2", role_assigned: "editor"} }
+      expect(@responder).to_not receive(:respond)
+      expect(@responder.meet_conditions?).to be_truthy
+    end
+  end
+
   describe "#call" do
     it "should not process message if responds_on? is false" do
       allow(subject).to receive(:responds_on?).and_return(false)


### PR DESCRIPTION
This PR adds a common setting `:if` to impose conditions on Responder:

- `:title` Responder will be run only if issue title matches this
- `:body` Responder will be run only if issue body matches this
- `:value` Responder will be run only if there is a value for this in the issue
- `:role_assigned` Responder will be run only if there is a username assigned for the specified value