### PR TITLE
Refactor settings file

### DIFF
--- a/app/buffy.rb
+++ b/app/buffy.rb
@@ -16,6 +16,6 @@ class Buffy < Sinatra::Base
   end
 
   get '/status' do
-    "#{settings.buffy[:bot_github_user]} in #{settings.environment}: up and running!"
+    "#{settings.buffy[:env][:bot_github_user]} in #{settings.environment}: up and running!"
   end
 end

--- a/app/lib/defaults.rb
+++ b/app/lib/defaults.rb
@@ -2,7 +2,7 @@ require 'sinatra/indifferent_hash'
 
 module Defaults
 
-  # Default value for needed settings.
+  # Default value for needed env settings.
   # Can be overriden from the config/settings YAML file.
   def default_settings
     @defaults ||= Sinatra::IndifferentHash[

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -7,7 +7,7 @@ module GitHub
 
   # Authenticated Octokit
   def github_client
-    @github_client ||= Octokit::Client.new(access_token: @settings[:gh_access_token], auto_paginate: true)
+    @github_client ||= Octokit::Client.new(access_token: @env[:gh_access_token], auto_paginate: true)
   end
 
   # returns the URL for a given template in the repo

--- a/app/lib/github_webhook_parser.rb
+++ b/app/lib/github_webhook_parser.rb
@@ -27,7 +27,7 @@ module GitHubWebhookParser
     end
 
     @sender = @payload.dig('sender', 'login')
-    if @sender == settings.buffy[:bot_github_user]
+    if @sender == settings.buffy[:env][:bot_github_user]
       halt 200, "Event origin discarded"
     end
 
@@ -51,7 +51,7 @@ module GitHubWebhookParser
   end
 
   def verify_signature
-    secret_token = settings.buffy[:gh_secret_token]
+    secret_token = settings.buffy[:env][:gh_secret_token]
     gh_signature = request.get_header 'HTTP_X_HUB_SIGNATURE'
     return halt 500, "Can't compute signature" if secret_token.nil? || secret_token.empty?
     return halt 403, 'Request missing signature' if gh_signature.nil? || gh_signature.empty?

--- a/app/lib/responder.rb
+++ b/app/lib/responder.rb
@@ -16,17 +16,19 @@ class Responder
   attr_accessor :event_action
   attr_accessor :params
   attr_accessor :teams
+  attr_accessor :env
   attr_accessor :bot_name
   attr_accessor :match_data
   attr_accessor :context
 
 
   def initialize(settings, params)
-    settings = default_settings.merge(settings)
-    @teams = settings[:teams]
-    @bot_name = settings[:bot_github_user]
-    @params = params || {}
+    settings[:env] = default_settings.merge(settings[:env] || {})
     @settings = settings
+    @env = @settings[:env]
+    @teams = settings[:teams]
+    @params = params || {}
+    @bot_name = @env[:bot_github_user]
     @context = nil
     define_listening
   end

--- a/app/lib/templating.rb
+++ b/app/lib/templating.rb
@@ -25,7 +25,7 @@ module Templating
 
   # Where the templates are located.
   def template_path
-    @template_path ||= @settings[:templates_path] || default_settings[:templates_path]
+    @template_path ||= @env[:templates_path] || default_settings[:templates_path]
     Pathname.new @template_path
   end
 

--- a/app/workers/buffy_worker.rb
+++ b/app/workers/buffy_worker.rb
@@ -21,7 +21,7 @@ class BuffyWorker
 
   sidekiq_options retry: false
 
-  attr_accessor :settings, :buffy_settings, :context
+  attr_accessor :env, :buffy_settings, :context
 
   def rack_environment
     ENV['RACK_ENV'] || 'test'
@@ -35,16 +35,16 @@ class BuffyWorker
     FileUtils.rm_rf(path) if Dir.exist?(path)
   end
 
-  def load_context_and_settings(config)
+  def load_context_and_env(config)
     @context = OpenStruct.new(config)
 
     document = ERB.new(IO.read("#{File.expand_path '../../../config', __FILE__}/settings-#{rack_environment}.yml")).result
     yaml = YAML.load(document)
     @buffy_settings = yaml['buffy']
 
-    @settings = {}
-    @settings[:templates_path] = buffy_settings['templates_path'] || default_settings[:templates_path]
-    @settings[:gh_access_token] = buffy_settings['gh_access_token'] || default_settings[:gh_access_token]
+    @env = {}
+    @env[:templates_path] = buffy_settings['env']['templates_path'] || default_settings[:templates_path]
+    @env[:gh_access_token] = buffy_settings['env']['gh_access_token'] || default_settings[:gh_access_token]
   end
 
   def setup_local_repo(url, branch)

--- a/app/workers/doi_worker.rb
+++ b/app/workers/doi_worker.rb
@@ -1,7 +1,7 @@
 class DOIWorker < BuffyWorker
 
   def perform(locals, url, branch)
-    load_context_and_settings(locals)
+    load_context_and_env(locals)
     return unless setup_local_repo(url, branch)
 
     paper = PaperFile.find(path)

--- a/app/workers/external_service_worker.rb
+++ b/app/workers/external_service_worker.rb
@@ -1,7 +1,7 @@
 class ExternalServiceWorker < BuffyWorker
 
   def perform(service, locals)
-    load_context_and_settings(locals)
+    load_context_and_env(locals)
 
     http_method = service['method'] || 'post'
     url = service['url']

--- a/app/workers/repo_checks_worker.rb
+++ b/app/workers/repo_checks_worker.rb
@@ -7,7 +7,7 @@ class RepoChecksWorker < BuffyWorker
   AVAILABLE_CHECKS = ["repo summary", "languages", "license", "statement of need"]
 
   def perform(locals, url, branch, checks)
-    load_context_and_settings(locals)
+    load_context_and_env(locals)
     return unless setup_local_repo(url, branch)
 
     if checks.nil? || checks.empty?

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -1,5 +1,6 @@
 buffy:
-  bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] || 'botsci' %>
+  env:
+    bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] || 'botsci' %>
   teams:
     editors: 3824115
     eics:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -1,7 +1,8 @@
 buffy:
-  bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] %>
-  gh_access_token: <%= ENV['BUFFY_GH_ACCESS_TOKEN'] %>
-  gh_secret_token: <%= ENV['BUFFY_GH_SECRET_TOKEN'] %>
+  env:
+    bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] %>
+    gh_access_token: <%= ENV['BUFFY_GH_ACCESS_TOKEN'] %>
+    gh_secret_token: <%= ENV['BUFFY_GH_SECRET_TOKEN'] %>
   teams:
     editors: 3824115
   responders:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -89,9 +89,9 @@ buffy:
           query_params:
             secret: A1234567890Z
           data_from_issue:
-            - target-repo
+            - target-repository
           mapping:
-            target_url: target-repo
+            target_url: target-repository
           headers:
             Authorization: OAUTH-token 123456
             Time-Zone: Europe/Amsterdam

--- a/config/settings-test.yml
+++ b/config/settings-test.yml
@@ -1,7 +1,8 @@
 buffy:
-  bot_github_user: 'botsci'
-  gh_access_token: 'secret-access'
-  gh_secret_token: 'secret-token'
+  env:
+    bot_github_user: 'botsci'
+    gh_access_token: 'secret-access'
+    gh_secret_token: 'secret-token'
   teams:
     editors: 2009411
     eics:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,9 +7,10 @@ A sample settings file will look similar to this:
 
 ```yaml
 buffy:
-  bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] %>
-  gh_access_token: <%= ENV['BUFFY_GH_ACCESS_TOKEN'] %>
-  gh_secret_token: <%= ENV['BUFFY_GH_SECRET_TOKEN'] %>
+  env:
+    bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] %>
+    gh_access_token: <%= ENV['BUFFY_GH_ACCESS_TOKEN'] %>
+    gh_secret_token: <%= ENV['BUFFY_GH_SECRET_TOKEN'] %>
   teams:
     editors: 3824115
     eics: myorg/editor-in-chief-team
@@ -44,15 +45,22 @@ buffy:
 The structure of the settings file starts with a single root node called `buffy`.
 It contains three main parts:
 
-  - A few simple key/value settings
+  - The `env` node
   - The `teams` node
   - The `responders` node
 
 A detailed description of all of them:
 
-## General configuration settings
+## Env: General configuration settings
 
-For security reasons is a good practice to load the secret values from your environment instead of hardcoding them in the code.
+```yaml
+  env:
+    bot_github_user: <%= ENV['BUFFY_BOT_GH_USER'] %>
+    gh_access_token: <%= ENV['BUFFY_GH_ACCESS_TOKEN'] %>
+    gh_secret_token: <%= ENV['BUFFY_GH_SECRET_TOKEN'] %>
+    templates_path: ".templates"
+```
+The _env_ section is used to declare general key/value settings. For security reasons is a good practice to load the secret values from your environment instead of hardcoding them in the code.
 
 <dl>
   <dt>bot_github_user</dt>

--- a/spec/buffy_spec.rb
+++ b/spec/buffy_spec.rb
@@ -8,9 +8,9 @@ describe Buffy do
 
   describe "initialization" do
     it "should parse the config file" do
-      expect(subject.settings.buffy["bot_github_user"]).to eq("botsci")
-      expect(subject.settings.buffy["gh_access_token"]).to eq("secret-access")
-      expect(subject.settings.buffy["gh_secret_token"]).to eq("secret-token")
+      expect(subject.settings.buffy["env"]["bot_github_user"]).to eq("botsci")
+      expect(subject.settings.buffy["env"]["gh_access_token"]).to eq("secret-access")
+      expect(subject.settings.buffy["env"]["gh_secret_token"]).to eq("secret-token")
       expect(subject.settings.buffy["teams"]["editors"]).to eq(2009411)
       expect(subject.settings.buffy["responders"]["hello"]["only"]).to eq("editors")
       expect(subject.settings.buffy["responders"]["thanks"]["hidden"]).to eq(true)

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -3,7 +3,7 @@ require_relative "./spec_helper.rb"
 describe "Github methods" do
 
   subject do
-    settings = Sinatra::IndifferentHash[teams: { editors: 11, reviewers: 22, eics: 33 }]
+    settings = Sinatra::IndifferentHash[env: {}, teams: { editors: 11, reviewers: 22, eics: 33 }]
     params ={ only: ["editors", "eics"] }
     Responder.new(settings, params)
   end

--- a/spec/responder_spec.rb
+++ b/spec/responder_spec.rb
@@ -222,7 +222,7 @@ describe Responder do
 
   describe "#locals" do
     before do
-      @responder = described_class.new({ bot_github_user: 'botsci' }, {})
+      @responder = described_class.new({ env: {bot_github_user: 'botsci'} }, {})
       @responder.context = OpenStruct.new(issue_id: 5,
                                           repo: "openjournals/buffy",
                                           sender: "user33",

--- a/spec/responders/add_and_remove_assignee_responder_spec.rb
+++ b/spec/responders/add_and_remove_assignee_responder_spec.rb
@@ -7,7 +7,7 @@ describe AddAndRemoveAssigneeResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -24,7 +24,7 @@ describe AddAndRemoveAssigneeResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       @responder.context = OpenStruct.new(repo: "openjournals/joss")
       disable_github_calls_for(@responder)
     end

--- a/spec/responders/add_and_remove_user_checklist_responder_spec.rb
+++ b/spec/responders/add_and_remove_user_checklist_responder_spec.rb
@@ -7,7 +7,7 @@ describe AddAndRemoveUserChecklistResponder do
   end
 
   before do
-    @responder = subject.new({bot_github_user: 'botsci'}, {template_file: 'checklist.md'})
+    @responder = subject.new({env: {bot_github_user: "botsci"}}, {template_file: 'checklist.md'})
   end
 
   describe "listening" do

--- a/spec/responders/assign_editor_responder_spec.rb
+++ b/spec/responders/assign_editor_responder_spec.rb
@@ -7,7 +7,7 @@ describe AssignEditorResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -26,7 +26,7 @@ describe AssignEditorResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       @responder.context = OpenStruct.new({ issue_body:"...Submission editor: <!--editor-->Pending<!--end-editor--> ..." })
       disable_github_calls_for(@responder)
 

--- a/spec/responders/assign_reviewer_n_responder_spec.rb
+++ b/spec/responders/assign_reviewer_n_responder_spec.rb
@@ -7,7 +7,7 @@ describe AssignReviewerNResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -25,7 +25,7 @@ describe AssignReviewerNResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
 
       @msg = "@botsci assign @arfon as reviewer 3"

--- a/spec/responders/basic_command_responder_spec.rb
+++ b/spec/responders/basic_command_responder_spec.rb
@@ -7,7 +7,7 @@ describe BasicCommandResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: "botsci"}, {command: "list editors"}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {command: "list editors"}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -29,7 +29,7 @@ describe BasicCommandResponder do
                  messages: ["msg 1", "msg 2"],
                  template_file: "editor_list.md",
                  data_from_issue: ["x"] }
-      @responder = subject.new({ bot_github_user: 'botsci' }, params)
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, params)
       @responder.context = OpenStruct.new(issue_id: 15,
                                           repo: "tests",
                                           sender: "rev33",
@@ -66,20 +66,20 @@ describe BasicCommandResponder do
   describe "misconfiguration" do
     it "should raise error if command is missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, {})
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       }.to raise_error "Configuration Error in BasicCommandResponder: No value for command."
     end
 
     it "should raise error if command is empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "    " })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "    " })
       }.to raise_error "Configuration Error in BasicCommandResponder: No value for command."
     end
   end
 
   describe "documentation" do
     it "#example_invocation shows the custom command" do
-      responder = subject.new({ bot_github_user: "botsci" }, { command: "list checkpoints" })
+      responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "list checkpoints" })
       expect(responder.example_invocation).to eq("@botsci list checkpoints")
     end
   end

--- a/spec/responders/check_references_responder_spec.rb
+++ b/spec/responders/check_references_responder_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper.rb"
 describe CheckReferencesResponder do
 
   before do
-    settings = { bot_github_user: "botsci" }
+    settings = { env: { bot_github_user: "botsci" }}
     @responder = CheckReferencesResponder.new(settings, {})
     @responder.context = OpenStruct.new(issue_body: "Test Review\n\n ... description ...")
     disable_github_calls_for(@responder)

--- a/spec/responders/close_issue_command_responder_spec.rb
+++ b/spec/responders/close_issue_command_responder_spec.rb
@@ -7,7 +7,7 @@ describe CloseIssueCommandResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { command: "reject" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reject" }) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe CloseIssueCommandResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" },
+      @responder = subject.new({ env: {bot_github_user: "botsci"}},
                                { name: "review_ok",
                                  command: "reject",
                                  add_labels: ["rejected"] })
@@ -58,20 +58,20 @@ describe CloseIssueCommandResponder do
   describe "misconfiguration" do
     it "should raise error if command is missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, {})
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       }.to raise_error "Configuration Error in CloseIssueCommandResponder: No value for command."
     end
 
     it "should raise error if command is empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "    " })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "    " })
       }.to raise_error "Configuration Error in CloseIssueCommandResponder: No value for command."
     end
   end
 
   describe "documentation" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" }, { command: "reject submission" })
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reject submission" })
     end
 
     it "#example_invocation shows the custom command" do

--- a/spec/responders/external_service_responder_spec.rb
+++ b/spec/responders/external_service_responder_spec.rb
@@ -8,7 +8,7 @@ describe ExternalServiceResponder do
 
   describe "listening" do
     before do
-      settings = { bot_github_user: "botsci" }
+      settings = { env: {bot_github_user: "botsci"} }
       params = { name: 'test-service', command: 'run tests', url: 'http://testing.openjournals.org' }
       @responder = subject.new(settings, params)
     end
@@ -25,7 +25,7 @@ describe ExternalServiceResponder do
 
   describe "#process_message" do
     before do
-      settings = { bot_github_user: "botsci" }
+      settings = { env: {bot_github_user: "botsci"} }
       params = { name: 'test-service', command: 'run tests', url: 'http://testing.openjournals.org' }
       @responder = subject.new(settings, params)
       @responder.context = OpenStruct.new(issue_id: 33,
@@ -61,19 +61,19 @@ describe ExternalServiceResponder do
   describe "misconfiguration" do
     it "should raise error if name is missing from config" do
       expect {
-        subject.new({ bot_github_user: "botsci" }, { command: 'run tests', url: 'URL' })
+        subject.new({env: {bot_github_user: "botsci"}}, { command: 'run tests', url: 'URL' })
       }.to raise_error "Configuration Error in ExternalServiceResponder: No value for name."
     end
 
     it "should raise error if there is no command" do
       expect {
-        subject.new({ bot_github_user: "botsci" }, { name: 'test', command: ' ', url: 'URL' })
+        subject.new({env: {bot_github_user: "botsci"}}, { name: 'test', command: ' ', url: 'URL' })
       }.to raise_error "Configuration Error in ExternalServiceResponder: No value for command."
     end
 
     it "should raise error if there is no url" do
       expect {
-        subject.new({ bot_github_user: "botsci" }, { name: 'test', command: 'run tests' })
+        subject.new({env: {bot_github_user: "botsci"}}, { name: 'test', command: 'run tests' })
       }.to raise_error "Configuration Error in ExternalServiceResponder: No value for url."
     end
   end

--- a/spec/responders/hello_responder_spec.rb
+++ b/spec/responders/hello_responder_spec.rb
@@ -7,7 +7,7 @@ describe HelloResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe HelloResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({bot_github_user: 'botsci'}, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
     end
 

--- a/spec/responders/help_responder_spec.rb
+++ b/spec/responders/help_responder_spec.rb
@@ -7,7 +7,7 @@ describe HelpResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: "botsci"}, {}) }
+    before { @responder = subject.new({env: { bot_github_user: "botsci" }}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -19,7 +19,7 @@ describe HelpResponder do
     end
 
     it "should allow invocation with custom command" do
-      custom_responder = subject.new({bot_github_user: "botsci"}, {help_command: "commands"})
+      custom_responder = subject.new({env: {bot_github_user: "botsci"}}, {help_command: "commands"})
       expect(custom_responder.event_regex).to match("@botsci commands")
       expect(custom_responder.event_regex).to_not match("@botsci help")
       expect(custom_responder.example_invocation).to eq("@botsci commands")
@@ -28,7 +28,7 @@ describe HelpResponder do
 
   describe "#process_message" do
     before do
-      @settings = { bot_github_user: "botsci",
+      @settings = { env: { bot_github_user: "botsci" },
                     teams: { editors: 2009411 },
                     responders: { "hello" => nil,
                                   "help" => nil,
@@ -57,7 +57,7 @@ describe HelpResponder do
     end
 
     it "should manage responder with multiple invocations" do
-      settings = { bot_github_user: "botsci", responders: { "help" => nil, "add_remove_assignee" => nil }}
+      settings = { env: { bot_github_user: "botsci" }, responders: { "help" => nil, "add_remove_assignee" => nil }}
       multiple_invocations = AddAndRemoveAssigneeResponder.new(settings, {})
       expected = [[@help.description, @help.example_invocation],
                   [multiple_invocations.description[0], multiple_invocations.example_invocation[0]],

--- a/spec/responders/invite_responder_spec.rb
+++ b/spec/responders/invite_responder_spec.rb
@@ -7,7 +7,7 @@ describe InviteResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -24,7 +24,7 @@ describe InviteResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({bot_github_user: 'botsci'}, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       allow(@responder).to receive(:invitations_url).and_return("../invitations")
       allow(@responder).to receive(:is_invited?).and_return(false)
       allow(@responder).to receive(:is_collaborator?).and_return(false)

--- a/spec/responders/label_command_responder_spec.rb
+++ b/spec/responders/label_command_responder_spec.rb
@@ -7,7 +7,7 @@ describe LabelCommandResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { command: "recommend publication", add_labels: ["ok"] }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "recommend publication", add_labels: ["ok"] }) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -24,7 +24,7 @@ describe LabelCommandResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" },
+      @responder = subject.new({ env: {bot_github_user: "botsci"}},
                                { name: "review_ok",
                                  command: "recommend publication",
                                  add_labels: ["reviewed", "approved", "pending publication"],
@@ -58,33 +58,33 @@ describe LabelCommandResponder do
   describe "misconfiguration" do
     it "should raise error if command is missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, {})
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       }.to raise_error "Configuration Error in LabelCommandResponder: No value for command."
     end
 
     it "should raise error if command is empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "    " })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "    " })
       }.to raise_error "Configuration Error in LabelCommandResponder: No value for command."
     end
 
     it "should raise error if labels and remove params are missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "reviewed" })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reviewed" })
         @responder.process_message(@msg)
       }.to raise_error "Configuration Error in LabelCommandResponder: No labels specified."
     end
 
     it "should raise error if labels and remove params are empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "reviewed", add_labels: [], remove_labels: [] })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reviewed", add_labels: [], remove_labels: [] })
         @responder.process_message(@msg)
       }.to raise_error "Configuration Error in LabelCommandResponder: No labels specified."
     end
 
     it "should raise error if labels param is not an array" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "reviewed", add_labels: "reviewed", remove_labels: [] })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reviewed", add_labels: "reviewed", remove_labels: [] })
         @responder.process_message(@msg)
       }.to raise_error "Configuration Error in LabelCommandResponder: No labels specified."
     end
@@ -99,7 +99,7 @@ describe LabelCommandResponder do
 
     it "should not raise error if only remove present" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { command: "reviewed", remove_labels: ["pending-review"] })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "reviewed", remove_labels: ["pending-review"] })
         expect(@responder).to receive(:issue_labels).and_return(["pending-review"])
         expect(@responder).to receive(:unlabel_issue).with("pending-review")
         @responder.process_message(@msg)
@@ -109,24 +109,24 @@ describe LabelCommandResponder do
 
   describe "documentation" do
     it "#example_invocation shows the custom command" do
-      responder = subject.new({ bot_github_user: "botsci" }, { command: "review finished", add_labels: ["reviewed"] })
+      responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "review finished", add_labels: ["reviewed"] })
       expect(responder.example_invocation).to eq("@botsci review finished")
     end
 
     it "#description should include only labels" do
-      responder = subject.new({ bot_github_user: "botsci" }, { command: "review finished", add_labels: ["reviewed"] })
+      responder = subject.new({env: {bot_github_user: "botsci"}}, { command: "review finished", add_labels: ["reviewed"] })
       expect(responder.description).to eq("Label issue with: reviewed")
     end
 
     it "#description should include only removed labels" do
       params = { command: "review finished", remove_labels: ["pending-review", "ongoing"] }
-      responder = subject.new({ bot_github_user: "botsci" }, params)
+      responder = subject.new({env: {bot_github_user: "botsci"}}, params)
       expect(responder.description).to eq("Remove labels: pending-review, ongoing")
     end
 
     it "#description should include added and removed labels" do
       params = { command: "review finished", add_labels: ["accepted"], remove_labels: ["ongoing review"] }
-      responder = subject.new({ bot_github_user: "botsci" }, params)
+      responder = subject.new({env: {bot_github_user: "botsci"}}, params)
       expect(responder.description).to eq("Label issue with: accepted. Remove labels: ongoing review")
     end
   end

--- a/spec/responders/list_of_values_responder_spec.rb
+++ b/spec/responders/list_of_values_responder_spec.rb
@@ -7,7 +7,7 @@ describe ListOfValuesResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { name: "reviewers" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "reviewers" }) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe ListOfValuesResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" }, { name: "reviewers" })
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "reviewers" })
       disable_github_calls_for(@responder)
     end
 
@@ -159,7 +159,7 @@ describe ListOfValuesResponder do
   end
 
   describe "#add_as_collaborator?" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { name: "reviewers" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "reviewers" }) }
 
     it "is false if value is not a username" do
       expect(@responder.username?("not username value")).to be_falsy
@@ -180,7 +180,7 @@ describe ListOfValuesResponder do
   end
 
   describe "#add_as_assignee?" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { name: "reviewers" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "reviewers" }) }
 
     it "is false if value is not a username" do
       expect(@responder.username?("not username value")).to be_falsy
@@ -203,20 +203,20 @@ describe ListOfValuesResponder do
   describe "misconfiguration" do
     it "should raise error if name is missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, {})
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       }.to raise_error "Configuration Error in ListOfValuesResponder: No value for name."
     end
 
     it "should raise error if name is empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { name: "    " })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "    " })
       }.to raise_error "Configuration Error in ListOfValuesResponder: No value for name."
     end
   end
 
   describe "documentation" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" }, { name: "observers", sample_value: "@observer_username"})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "observers", sample_value: "@observer_username"})
     end
 
     it "#description should include name" do

--- a/spec/responders/remove_editor_responder_spec.rb
+++ b/spec/responders/remove_editor_responder_spec.rb
@@ -7,7 +7,7 @@ describe RemoveEditorResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe RemoveEditorResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
 
       @msg = "@botsci remove editor"

--- a/spec/responders/remove_reviewer_n_responder_spec.rb
+++ b/spec/responders/remove_reviewer_n_responder_spec.rb
@@ -7,7 +7,7 @@ describe RemoveReviewerNResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: 'botsci'}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe RemoveReviewerNResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
 
       @msg = "@botsci remove reviewer 33"

--- a/spec/responders/repo_checks_responder_spec.rb
+++ b/spec/responders/repo_checks_responder_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper.rb"
 describe RepoChecksResponder do
 
   before do
-    settings = { bot_github_user: "botsci" }
+    settings = { env: { bot_github_user: "botsci" }}
     @responder = RepoChecksResponder.new(settings, {})
     @responder.context = OpenStruct.new(issue_body: "Test Review\n\n ... description ...")
     @responder.context.issue_body +=  "<!--target-repository-->http://repo.url<!--end-target-repository-->"

--- a/spec/responders/set_value_responder_spec.rb
+++ b/spec/responders/set_value_responder_spec.rb
@@ -7,7 +7,7 @@ describe SetValueResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({ bot_github_user: "botsci" }, { name: "version" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "version" }) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -23,7 +23,7 @@ describe SetValueResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" }, { name: "version" })
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "version" })
       disable_github_calls_for(@responder)
 
       @msg = "@botsci set v0.0.33-alpha as version"
@@ -54,20 +54,20 @@ describe SetValueResponder do
   describe "misconfiguration" do
     it "should raise error if name is missing from config" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, {})
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       }.to raise_error "Configuration Error in SetValueResponder: No value for name."
     end
 
     it "should raise error if name is empty" do
       expect {
-        @responder = subject.new({ bot_github_user: "botsci" }, { name: "    " })
+        @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "    " })
       }.to raise_error "Configuration Error in SetValueResponder: No value for name."
     end
   end
 
   describe "documentation" do
     before do
-      @responder = subject.new({ bot_github_user: "botsci" }, { name: "archive", sample_value: "10.21105/joss.12345"})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { name: "archive", sample_value: "10.21105/joss.12345"})
     end
 
     it "#description should include name" do

--- a/spec/responders/thanks_responder_spec.rb
+++ b/spec/responders/thanks_responder_spec.rb
@@ -7,7 +7,7 @@ describe ThanksResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: "botsci"}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new comments" do
       expect(@responder.event_action).to eq("issue_comment.created")
@@ -24,7 +24,7 @@ describe ThanksResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
     end
 

--- a/spec/responders/welcome_responder_spec.rb
+++ b/spec/responders/welcome_responder_spec.rb
@@ -7,7 +7,7 @@ describe WelcomeResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: "botsci"}, {}) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, {}) }
 
     it "should listen to new issues" do
       expect(@responder.event_action).to eq("issues.opened")
@@ -20,7 +20,7 @@ describe WelcomeResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, {})
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, {})
       disable_github_calls_for(@responder)
     end
 

--- a/spec/responders/welcome_template_responder_spec.rb
+++ b/spec/responders/welcome_template_responder_spec.rb
@@ -7,7 +7,7 @@ describe WelcomeTemplateResponder do
   end
 
   describe "listening" do
-    before { @responder = subject.new({bot_github_user: "botsci"}, { template_file: "test.md" }) }
+    before { @responder = subject.new({env: {bot_github_user: "botsci"}}, { template_file: "test.md" }) }
 
     it "should listen to new issues" do
       expect(@responder.event_action).to eq("issues.opened")
@@ -20,7 +20,7 @@ describe WelcomeTemplateResponder do
 
   describe "#process_message" do
     before do
-      @responder = subject.new({ bot_github_user: 'botsci' }, { template_file: "test.md", data_from_issue: ["reviewer"] })
+      @responder = subject.new({env: {bot_github_user: "botsci"}}, { template_file: "test.md", data_from_issue: ["reviewer"] })
       @responder.context = OpenStruct.new(issue_id: 5,
                                           repo: "openjournals/buffy",
                                           sender: "user33",

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -1,9 +1,9 @@
 module CommonActions
   def with_secret_token(new_value, &block)
-      old_value = subject.settings.buffy[:gh_secret_token]
-      subject.settings.buffy[:gh_secret_token] = new_value
+      old_value = subject.settings.buffy[:env][:gh_secret_token]
+      subject.settings.buffy[:env][:gh_secret_token] = new_value
       yield
-      subject.settings.buffy[:gh_secret_token] = old_value
+      subject.settings.buffy[:env][:gh_secret_token] = old_value
     end
 
   def signature_for(payload)

--- a/spec/templating_spec.rb
+++ b/spec/templating_spec.rb
@@ -30,7 +30,7 @@ describe "Templating" do
     end
 
     it "should return the template path specified in settings" do
-      responder = Responder.new({ templates_path: "./mytemplates/custom" }, {})
+      responder = Responder.new({env: {templates_path: "./mytemplates/custom"} }, {})
       expect(responder.template_path.to_s).to eq("./mytemplates/custom")
     end
   end

--- a/spec/workers/buffy_worker_spec.rb
+++ b/spec/workers/buffy_worker_spec.rb
@@ -17,15 +17,15 @@ describe BuffyWorker do
     expect(BuffyWorker.new.rack_environment).to eq('test')
   end
 
-  describe "#load_context_and_settings" do
+  describe "#load_context_and_env" do
     before do
       config = { 'issue_id' => 333, 'repo' => 'openjournals/testing' }
       @worker = BuffyWorker.new
-      @worker.load_context_and_settings(config)
+      @worker.load_context_and_env(config)
     end
 
     it "should read settings file" do
-      expect(@worker.buffy_settings['gh_secret_token']).to eq('secret-token')
+      expect(@worker.buffy_settings['env']['gh_secret_token']).to eq('secret-token')
       expect(@worker.buffy_settings['teams']['editors']).to eq(2009411)
     end
 
@@ -34,9 +34,9 @@ describe BuffyWorker do
       expect(@worker.context[:repo]).to eq('openjournals/testing')
     end
 
-    it "should load settings" do
-      expect(@worker.settings[:templates_path]).to eq('.buffy/templates')
-      expect(@worker.settings[:gh_access_token]).to eq('secret-access')
+    it "should load env" do
+      expect(@worker.env[:templates_path]).to eq('.buffy/templates')
+      expect(@worker.env[:gh_access_token]).to eq('secret-access')
     end
   end
 


### PR DESCRIPTION
Added new `env` section.
The goal is to simplify the organization of all settings, now under only 3 main sections: `env`, `teams` and `responders`