### PR TITLE
Auto register responders

### DIFF
--- a/app/lib/responder.rb
+++ b/app/lib/responder.rb
@@ -21,6 +21,14 @@ class Responder
   attr_accessor :match_data
   attr_accessor :context
 
+  def self.keyname(key)
+    @key = key.to_s
+  end
+
+  def self.key
+    @key || self.name
+  end
+
 
   def initialize(settings, params)
     settings[:env] = default_settings.merge(settings[:env] || {})

--- a/app/responders/add_and_remove_assignee_responder.rb
+++ b/app/responders/add_and_remove_assignee_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AddAndRemoveAssigneeResponder < Responder
 
+  keyname :add_remove_assignee
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} (add|remove) assignee: (\S+)\s*\z/i

--- a/app/responders/add_and_remove_user_checklist_responder.rb
+++ b/app/responders/add_and_remove_user_checklist_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AddAndRemoveUserChecklistResponder < Responder
 
+  keyname :add_remove_checklist
+
   def define_listening
     required_params :template_file
 

--- a/app/responders/assign_editor_responder.rb
+++ b/app/responders/assign_editor_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AssignEditorResponder < Responder
 
+  keyname :assign_editor
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} assign (\S+) as editor\s*\z/i

--- a/app/responders/assign_reviewer_n_responder.rb
+++ b/app/responders/assign_reviewer_n_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class AssignReviewerNResponder < Responder
 
+  keyname :assign_reviewer_n
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} assign (\S+) as reviewer (\S+)\s*\z/i

--- a/app/responders/basic_command_responder.rb
+++ b/app/responders/basic_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class BasicCommandResponder < Responder
 
+  keyname :basic_command
+
   def define_listening
     required_params :command
 

--- a/app/responders/check_references_responder.rb
+++ b/app/responders/check_references_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class CheckReferencesResponder < Responder
 
+  keyname :check_references
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} check references(?: from branch ([\w-]+))?\s*\z/i

--- a/app/responders/close_issue_command_responder.rb
+++ b/app/responders/close_issue_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class CloseIssueCommandResponder < Responder
 
+  keyname :close_issue_command
+
   def define_listening
     required_params :command
 

--- a/app/responders/external_service_responder.rb
+++ b/app/responders/external_service_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ExternalServiceResponder < Responder
 
+  keyname :external_service
+
   def define_listening
     required_params :name, :command, :url
 

--- a/app/responders/hello_responder.rb
+++ b/app/responders/hello_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class HelloResponder < Responder
 
+  keyname :hello
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A(Hello|Hi) @#{@bot_name}\s*\z/i

--- a/app/responders/help_responder.rb
+++ b/app/responders/help_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class HelpResponder < Responder
 
+  keyname :help
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} #{help_command}\s*\z/i

--- a/app/responders/invite_responder.rb
+++ b/app/responders/invite_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class InviteResponder < Responder
 
+  keyname :invite
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} invite (\S+)\s*\z/i

--- a/app/responders/label_command_responder.rb
+++ b/app/responders/label_command_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class LabelCommandResponder < Responder
 
+  keyname :label_command
+
   def define_listening
     required_params :command
     check_labels_present

--- a/app/responders/list_of_values_responder.rb
+++ b/app/responders/list_of_values_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ListOfValuesResponder < Responder
 
+  keyname :list_of_values
+
   def define_listening
     required_params :name
 

--- a/app/responders/remove_editor_responder.rb
+++ b/app/responders/remove_editor_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RemoveEditorResponder < Responder
 
+  keyname :remove_editor
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} remove editor\s*\z/i

--- a/app/responders/remove_reviewer_n_responder.rb
+++ b/app/responders/remove_reviewer_n_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RemoveReviewerNResponder < Responder
 
+  keyname :remove_reviewer_n
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} remove reviewer (\S+)\s*\z/i

--- a/app/responders/repo_checks_responder.rb
+++ b/app/responders/repo_checks_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class RepoChecksResponder < Responder
 
+  keyname :repo_checks
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A@#{@bot_name} check repository(?: from branch ([\w-]+))?\s*\z/i

--- a/app/responders/set_value_responder.rb
+++ b/app/responders/set_value_responder.rb
@@ -2,6 +2,8 @@ require_relative "../lib/responder"
 
 class SetValueResponder < Responder
 
+  keyname :set_value
+
   def define_listening
     required_params :name
 

--- a/app/responders/thanks_responder.rb
+++ b/app/responders/thanks_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class ThanksResponder < Responder
 
+  keyname :thanks
+
   def define_listening
     @event_action = "issue_comment.created"
     @event_regex = /\A(@#{@bot_name} thanks|@#{@bot_name} thank you|thanks @#{@bot_name}|thank you @#{@bot_name})/i

--- a/app/responders/welcome_responder.rb
+++ b/app/responders/welcome_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class WelcomeResponder < Responder
 
+  keyname :welcome
+
   def define_listening
     @event_action = "issues.opened"
     @event_regex = nil

--- a/app/responders/welcome_template_responder.rb
+++ b/app/responders/welcome_template_responder.rb
@@ -2,6 +2,8 @@ require_relative '../lib/responder'
 
 class WelcomeTemplateResponder < Responder
 
+  keyname :welcome_template
+
   def define_listening
     required_params :template_file
 

--- a/spec/responder_registry_spec.rb
+++ b/spec/responder_registry_spec.rb
@@ -15,6 +15,11 @@ describe ResponderRegistry do
   end
 
   describe "initialization" do
+    it "should load available responders mapping" do
+      registry = described_class.new(@config)
+      expect(registry.responders_map).to eq(ResponderRegistry.available_responders)
+    end
+
     it "should load single responders" do
       registry = described_class.new(@config)
       single_responder = registry.responders.select { |r| r.kind_of?(AssignReviewerNResponder) }
@@ -58,6 +63,17 @@ describe ResponderRegistry do
         expect(responder.teams[:editors]).to eq(expected_teams[:editors])
         expect(responder.teams[:eics]).to eq(expected_teams[:eics])
       end
+    end
+  end
+
+  describe ".available_responders" do
+    it "should return a map of all available responders" do
+      map = ResponderRegistry.available_responders
+      files_count = Dir["#{File.expand_path '../../app/responders', __FILE__}/**/*.rb"].length
+      expect(map.count).to eq(files_count)
+
+      random_responder_key = map.keys[(0..files_count-1).to_a.sample]
+      expect(map[random_responder_key].key).to eq(random_responder_key)
     end
   end
 

--- a/spec/responder_spec.rb
+++ b/spec/responder_spec.rb
@@ -259,9 +259,29 @@ describe Responder do
     end
   end
 
+  describe ".keyname" do
+    it "should be class name by default" do
+      expect(described_class.key).to eq("Responder")
+    end
+
+    it "should set the key name" do
+      described_class.keyname :buffy_tester
+      expect(described_class.key).to eq("buffy_tester")
+    end
+  end
+
+  describe "#key" do
+    it "should be present for all responders" do
+      ResponderRegistry.available_responders.values.each do |responder_class|
+        expect(responder_class.key).to_not be_nil
+        expect(responder_class.key).to_not eq(responder_class.name)
+      end
+    end
+  end
+
   describe "#description" do
     it "should be present for all responders" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         expect(responder.respond_to?(:description)).to eq(true)
         expect(responder.description).to_not be_nil
@@ -272,7 +292,7 @@ describe Responder do
 
   describe "#example_invocation" do
     it "should be present for all responders" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         expect(responder.respond_to?(:example_invocation)).to eq(true)
         expect(responder.example_invocation).to_not be_nil
@@ -283,7 +303,7 @@ describe Responder do
 
   describe "multiple descriptions and example invocations" do
     it "should have the same number of each of them" do
-      ResponderRegistry::RESPONDER_MAPPING.values.each do |responder_class|
+      ResponderRegistry.available_responders.values.each do |responder_class|
         responder = responder_class.new({}, sample_params(responder_class))
         if responder.description.is_a?(Array) || responder.example_invocation.is_a?(Array)
           error_msg = "#{responder_class.name} descriptions and example_invocations sizes don't match"


### PR DESCRIPTION
This PR removes the hardcoded map of responders and makes the `ResponderRegistry` to scan all the responders dir to create automatically the `key: responder` mapping.