### PR TITLE
Configure teams as array of users

### DIFF
--- a/app/lib/authorizations.rb
+++ b/app/lib/authorizations.rb
@@ -1,8 +1,7 @@
 module Authorizations
 
-  def authorized_team_ids
-    @authorized_team_ids ||= begin
-      team_ids = []
+  def authorized_teams
+    @authorized_teams ||= begin
       teams_ids_or_names = []
       case params[:only]
       when String
@@ -10,8 +9,26 @@ module Authorizations
       when Array
         params[:only].each { |team_name| teams_ids_or_names << @teams[team_name] }
       end
+      teams_ids_or_names
+    end
+  end
 
-      teams_ids_or_names.each do |team_id_or_name|
+  def authorized_users
+    @authorized_users ||= begin
+      user_handles = []
+      authorized_teams.each do |team|
+        if team.is_a?(Array)
+          user_handles += team
+        end
+      end
+      user_handles.uniq
+    end
+  end
+
+  def authorized_team_ids
+    @authorized_team_ids ||= begin
+      team_ids = []
+      authorized_teams.each do |team_id_or_name|
         case team_id_or_name
         when Integer
           team_ids << team_id_or_name
@@ -47,6 +64,10 @@ module Authorizations
         ""
       end
     end
+  end
+
+  def user_authorized?(user_login)
+    authorized_users.include?(user_login) || user_in_authorized_teams?(user_login)
   end
 
 end

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -112,7 +112,7 @@ module GitHub
 
   # Returns true if the user in a team member of any of the authorized teams
   # false otherwise
-  def user_authorized?(user_login)
+  def user_in_authorized_teams?(user_login)
     @user_authorized ||= begin
       authorized = []
       authorized_team_ids.each do |team_id|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,12 +83,21 @@ The _env_ section is used to declare general key/value settings. For security re
     editors: 3824117
     eics: myorg/editor-in-chief-team
     reviewers: 45363564
+    collaborators:
+      - user33
+      - user42
 ```
  The optional teams node includes entries to reference GitHub teams, used later to grant access to responders only to users belonging to specific teams. The teams referred here must be __visible__ teams of the organization owner of the repositories where the reviews will take place. Multiple entries can be added to the teams node. All entries follow this simple format:
 
  <dl>
   <dt>key: value</dt>
-  <dd>Where <em>key</em> is the name for this team in Buffy and <em>value</em> can be the integer id of the team in GitHub (preferred) or the reference in format <em>organization/name</em> (for example: <em>openjournals/editors</em>)</dd>
+  <dd>Where <em>key</em> is the name for this team in Buffy and <em>value</em> can be:
+    <dl>
+      <dd>- The integer <strong>id of the team</strong> in GitHub (preferred)</dd>
+      <dd>- The <strong>reference</strong> in format <em>organization/name</em> (for example: <em>openjournals/editors</em>)</dd>
+      <dd>- An array of user handles</dd>
+    </dl>
+  </dd>
 </dl>
 
 ## Responders

--- a/spec/authorizations_spec.rb
+++ b/spec/authorizations_spec.rb
@@ -3,15 +3,28 @@ require_relative "./spec_helper.rb"
 describe "Authorizations" do
 
   subject do
-    settings = Sinatra::IndifferentHash[teams: { editors: 11, reviewers: 22, eics: 33, guests: "orgbuffy/guests", empty: nil }]
-    params = { only: ['editors', 'eics'] }
+    settings = Sinatra::IndifferentHash[teams:
+      { editors: 11,
+        reviewers: 22,
+        eics: 33,
+        guests: "orgbuffy/guests",
+        trusted_people: ["user33", "user42"],
+        empty: nil }]
+    params = { only: ['editors', 'eics', 'trusted_people'] }
     Responder.new(settings, params)
+  end
+
+  describe "#authorized_teams" do
+    it "should return authorized team values from the config" do
+      subject.params = { only: ['editors', 'guests', 'trusted_people'] }
+      expect(subject.authorized_teams).to eq([11, "orgbuffy/guests", ["user33", "user42"]])
+    end
   end
 
   context "#authorized_team_ids" do
     describe "when there is no restrictions via :only param" do
       it "should return nothing" do
-        subject.params = { }
+        subject.params = {}
         expect(subject.authorized_team_ids).to eq([])
       end
     end
@@ -44,17 +57,63 @@ describe "Authorizations" do
         expect(subject.authorized_team_ids).to eq([])
       end
     end
+
+    describe "when a team with user handles is received" do
+      it "should return nothing" do
+        subject.params = { only: ['trusted_people'] }
+        expect(subject.authorized_team_ids).to eq([])
+      end
+    end
+
+    describe "when all kind of teams are received" do
+      it "should return ids of named teams" do
+        subject.params = { only: ['reviewers', 'guests', 'trusted_people', 'empty'] }
+        expect(subject).to receive(:team_id).once.with("orgbuffy/guests").and_return(44)
+        expect(subject.authorized_team_ids).to eq([22, 44])
+      end
+    end
   end
 
   describe "#authorized_team_names" do
     it "should return names of all authorized teams" do
-      expect(subject.authorized_team_names).to eq(['editors', 'eics'])
+      expect(subject.authorized_team_names).to eq(['editors', 'eics', 'trusted_people'])
     end
   end
 
   describe "#authorized_teams_sentence" do
     it "should return a sentence of names of all authorized teams" do
-      expect(subject.authorized_teams_sentence).to eq('editors and eics')
+      expect(subject.authorized_teams_sentence).to eq('editors, eics and trusted_people')
+    end
+  end
+
+  describe "#authorized_users" do
+    it "should return users specified in the config" do
+      subject.params = { only: ['trusted_people'] }
+      expect(subject.authorized_users).to eq(['user33', 'user42'])
+    end
+
+    it "should ignore ids or team names" do
+      subject.params = { only: ['eics', 'guests', 'trusted_people'] }
+      expect(subject.authorized_users).to eq(['user33', 'user42'])
+    end
+  end
+
+  describe "#user_authorized?" do
+    it "should be true if user is authorized" do
+      subject.params = { only: ['trusted_people'] }
+      expect(subject.user_authorized?('user33')).to be_truthy
+    end
+
+    it "should be true if user is in an authorized team" do
+      subject.params = { only: ['eics'] }
+      expect(subject).to receive(:user_in_authorized_teams?).once.with("user77").and_return(true)
+      expect(subject.user_authorized?('user77')).to be_truthy
+    end
+
+    it "should be false if user is not authorized" do
+      subject.params = { only: ['eics'] }
+      expect(subject).to receive(:user_in_authorized_teams?).once.with("user77").and_return(false)
+      expect(subject.user_authorized?('user77')).to be_falsy
     end
   end
 

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -224,13 +224,13 @@ describe "Github methods" do
     end
   end
 
-  describe "#user_authorized?" do
+  describe "#user_in_authorized_teams?" do
     it "should return true if user is member of any authorized team" do
       expect_any_instance_of(Octokit::Client).to receive(:team_member?).once.with(11, "sender").and_return(true)
       expect_any_instance_of(Octokit::Client).to receive(:team_member?).never.with(22, "sender")
       expect_any_instance_of(Octokit::Client).to receive(:team_member?).never.with(33, "sender")
 
-      expect(subject.user_authorized?("sender")).to be_truthy
+      expect(subject.user_in_authorized_teams?("sender")).to be_truthy
     end
 
     it "should return false if user is not member of any authorized team" do
@@ -238,7 +238,7 @@ describe "Github methods" do
       expect_any_instance_of(Octokit::Client).to receive(:team_member?).never.with(22, "sender")
       expect_any_instance_of(Octokit::Client).to receive(:team_member?).once.with(33, "sender").and_return(false)
 
-      expect(subject.user_authorized?("sender")).to be_falsey
+      expect(subject.user_in_authorized_teams?("sender")).to be_falsey
     end
   end
 


### PR DESCRIPTION
This PR allow to add teams in the config yml file as a list of users.
```yml
teams:
    editors:
        - user1
        - user2

```
It allows to have authorization without needing admin privileges.