### PR TITLE
CI: Print Ruby version w/o Bundler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,5 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: |
-        bundle exec ruby -v
+        ruby -v
         bundle exec rspec spec


### PR DESCRIPTION
This PR removes 1 usage of Bundler, which seems to be not necessary.