### PR TITLE
Allow comments in other lines after commands

### DIFF
--- a/app/responders/add_and_remove_assignee_responder.rb
+++ b/app/responders/add_and_remove_assignee_responder.rb
@@ -6,7 +6,7 @@ class AddAndRemoveAssigneeResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} (add|remove) assignee: ([@\w-]+)\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} (add|remove) assignee: ([@\w-]+)\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/add_and_remove_user_checklist_responder.rb
+++ b/app/responders/add_and_remove_user_checklist_responder.rb
@@ -8,7 +8,7 @@ class AddAndRemoveUserChecklistResponder < Responder
     required_params :template_file
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} (add|remove) checklist for ([@\w-]+)\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} (add|remove) checklist for ([@\w-]+)\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/assign_editor_responder.rb
+++ b/app/responders/assign_editor_responder.rb
@@ -6,7 +6,7 @@ class AssignEditorResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} (assign|add) (\S+) as editor\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} (assign|add) (\S+) as editor\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/basic_command_responder.rb
+++ b/app/responders/basic_command_responder.rb
@@ -8,7 +8,7 @@ class BasicCommandResponder < Responder
     required_params :command
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/check_references_responder.rb
+++ b/app/responders/check_references_responder.rb
@@ -6,7 +6,7 @@ class CheckReferencesResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} check references(?: from branch ([\/\w-]+))?\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} check references(?: from branch ([\/\w-]+))?\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/close_issue_command_responder.rb
+++ b/app/responders/close_issue_command_responder.rb
@@ -8,7 +8,7 @@ class CloseIssueCommandResponder < Responder
     required_params :command
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/external_service_responder.rb
+++ b/app/responders/external_service_responder.rb
@@ -8,7 +8,7 @@ class ExternalServiceResponder < Responder
     required_params :name, :command, :url
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/external_start_review_responder.rb
+++ b/app/responders/external_start_review_responder.rb
@@ -8,7 +8,7 @@ class ExternalStartReviewResponder < Responder
     required_params :external_call
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} start review\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} start review\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/github_action_responder.rb
+++ b/app/responders/github_action_responder.rb
@@ -8,7 +8,7 @@ class GithubActionResponder < Responder
     required_params :workflow_repo, :workflow_name, :command
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/hello_responder.rb
+++ b/app/responders/hello_responder.rb
@@ -6,7 +6,7 @@ class HelloResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A(Hello|Hi) @#{bot_name}[\.!]?\s*\z/i
+    @event_regex = /\A(Hello|Hi) @#{bot_name}[\.!]?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/help_responder.rb
+++ b/app/responders/help_responder.rb
@@ -6,7 +6,7 @@ class HelpResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{help_command}[\.!]?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{help_command}[\.!]?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/invite_responder.rb
+++ b/app/responders/invite_responder.rb
@@ -6,7 +6,7 @@ class InviteResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} invite ([@\w-]+)\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} invite ([@\w-]+)\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/label_command_responder.rb
+++ b/app/responders/label_command_responder.rb
@@ -9,7 +9,7 @@ class LabelCommandResponder < Responder
     check_labels_present
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/list_of_values_responder.rb
+++ b/app/responders/list_of_values_responder.rb
@@ -8,7 +8,7 @@ class ListOfValuesResponder < Responder
     required_params :name
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} (add|remove) (\S+) (to|from) #{name}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} (add|remove) (\S+) (to|from) #{name}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/list_team_members_responder.rb
+++ b/app/responders/list_team_members_responder.rb
@@ -8,7 +8,7 @@ class ListTeamMembersResponder < Responder
     required_params :command, :team_id
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/reminders_responder.rb
+++ b/app/responders/reminders_responder.rb
@@ -7,7 +7,7 @@ class RemindersResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} remind (.*) in (.*) (.*)\s*\z/i
+    @event_regex = /\A@#{bot_name} remind (.*) in (.*) (.*)\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/remove_editor_responder.rb
+++ b/app/responders/remove_editor_responder.rb
@@ -6,7 +6,7 @@ class RemoveEditorResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} remove editor\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} remove editor\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/repo_checks_responder.rb
+++ b/app/responders/repo_checks_responder.rb
@@ -6,7 +6,7 @@ class RepoChecksResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} check repository(?: from branch ([\/\w-]+))?\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} check repository(?: from branch ([\/\w-]+))?\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/reviewer_checklist_comment_responder.rb
+++ b/app/responders/reviewer_checklist_comment_responder.rb
@@ -8,7 +8,7 @@ class ReviewerChecklistCommentResponder < Responder
     required_params :template_file
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} #{command}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} #{command}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/reviewers_list_responder.rb
+++ b/app/responders/reviewers_list_responder.rb
@@ -6,7 +6,7 @@ class ReviewersListResponder < Responder
 
   def define_listening
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} (add|remove) (\S+) (to reviewers|from reviewers|as reviewer)\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} (add|remove) (\S+) (to reviewers|from reviewers|as reviewer)\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/set_value_responder.rb
+++ b/app/responders/set_value_responder.rb
@@ -8,7 +8,7 @@ class SetValueResponder < Responder
     required_params :name
 
     @event_action = "issue_comment.created"
-    @event_regex = /\A@#{bot_name} set (.*) as #{name}\.?\s*\z/i
+    @event_regex = /\A@#{bot_name} set (.*) as #{name}\.?\s*$/i
   end
 
   def process_message(message)

--- a/app/responders/wrong_command_responder.rb
+++ b/app/responders/wrong_command_responder.rb
@@ -6,7 +6,7 @@ class WrongCommandResponder < Responder
 
   def define_listening
     @event_action = "wrong_command"
-    @event_regex = /\A@#{bot_name} (.*)/i
+    @event_regex = /\A@#{bot_name} (.*)$/i
   end
 
   def process_message(message)

--- a/spec/responders/add_and_remove_assignee_responder_spec.rb
+++ b/spec/responders/add_and_remove_assignee_responder_spec.rb
@@ -16,7 +16,7 @@ describe AddAndRemoveAssigneeResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci add assignee: @arfon")
       expect(@responder.event_regex).to match("@botsci add assignee: @arfon.")
-      expect(@responder.event_regex).to match("@botsci remove assignee: @arfon   \r\n")
+      expect(@responder.event_regex).to match("@botsci remove assignee: @arfon   \r\n more")
       expect(@responder.event_regex).to_not match("remove assignee: @arfon")
       expect(@responder.event_regex).to_not match("@botsci remove assignee: @arfon and others")
       expect(@responder.event_regex).to_not match("@botsci add assignee @arfon")

--- a/spec/responders/add_and_remove_user_checklist_responder_spec.rb
+++ b/spec/responders/add_and_remove_user_checklist_responder_spec.rb
@@ -18,7 +18,7 @@ describe AddAndRemoveUserChecklistResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci add checklist for @arfon")
       expect(@responder.event_regex).to match("@botsci add checklist for @arfon.")
-      expect(@responder.event_regex).to match("@botsci remove checklist for @arfon   \r\n")
+      expect(@responder.event_regex).to match("@botsci remove checklist for @arfon   \r\n more")
       expect(@responder.event_regex).to_not match("remove checklist for @arfon")
       expect(@responder.event_regex).to_not match("@botsci add checklist for @arfon and others")
       expect(@responder.event_regex).to_not match("@botsci add checklist for ")

--- a/spec/responders/assign_editor_responder_spec.rb
+++ b/spec/responders/assign_editor_responder_spec.rb
@@ -15,7 +15,8 @@ describe AssignEditorResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci assign @arfon as editor")
-      expect(@responder.event_regex).to match("@botsci assign @xuanxu as editor   \r\n")
+      expect(@responder.event_regex).to match("@botsci assign @xuanxu as editor   ")
+      expect(@responder.event_regex).to match("@botsci assign @xuanxu as editor   \r\n more")
       expect(@responder.event_regex).to match("@botsci assign me as editor")
       expect(@responder.event_regex).to match("@botsci add me as editor")
       expect(@responder.event_regex).to match("@botsci add @arfon as editor")

--- a/spec/responders/basic_command_responder_spec.rb
+++ b/spec/responders/basic_command_responder_spec.rb
@@ -16,6 +16,7 @@ describe BasicCommandResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci list editors")
       expect(@responder.event_regex).to match("@botsci list editors      \n")
+      expect(@responder.event_regex).to match("@botsci list editors      \r\n more")
       expect(@responder.event_regex).to_not match("@botsci list ")
       expect(@responder.event_regex).to_not match("```@botsci list editors")
     end

--- a/spec/responders/check_references_responder_spec.rb
+++ b/spec/responders/check_references_responder_spec.rb
@@ -17,7 +17,7 @@ describe CheckReferencesResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci check references")
-      expect(@responder.event_regex).to match("@botsci check references    \r\n")
+      expect(@responder.event_regex).to match("@botsci check references    \r\n ignored part")
       expect(@responder.event_regex).to match("@botsci check references from branch custom-branch")
       expect(@responder.event_regex).to match("@botsci check references from branch custom/branch")
       expect(@responder.event_regex).to match("@botsci check references from branch development    \r\n")

--- a/spec/responders/close_issue_command_responder_spec.rb
+++ b/spec/responders/close_issue_command_responder_spec.rb
@@ -15,7 +15,8 @@ describe CloseIssueCommandResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci reject")
-      expect(@responder.event_regex).to match("@botsci reject   \r\n")
+      expect(@responder.event_regex).to match("@botsci reject   ")
+      expect(@responder.event_regex).to match("@botsci reject   \r\n a comment")
       expect(@responder.event_regex).to_not match("@botsci reject publication")
       expect(@responder.event_regex).to_not match("@botsci rejec")
     end

--- a/spec/responders/external_service_responder_spec.rb
+++ b/spec/responders/external_service_responder_spec.rb
@@ -19,7 +19,8 @@ describe ExternalServiceResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci run tests")
-      expect(@responder.event_regex).to match("@botsci run tests   \r\n")
+      expect(@responder.event_regex).to match("@botsci run tests   ")
+      expect(@responder.event_regex).to match("@botsci run tests   \r\n more")
     end
   end
 

--- a/spec/responders/external_start_review_responder_spec.rb
+++ b/spec/responders/external_start_review_responder_spec.rb
@@ -19,7 +19,8 @@ describe ExternalStartReviewResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci start review")
-      expect(@responder.event_regex).to match("@botsci start review   \r\n")
+      expect(@responder.event_regex).to match("@botsci start review  ")
+      expect(@responder.event_regex).to match("@botsci start review   \r\n other comment \r\n more")
     end
   end
 

--- a/spec/responders/github_action_responder_spec.rb
+++ b/spec/responders/github_action_responder_spec.rb
@@ -19,7 +19,8 @@ describe GithubActionResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci generate pdf")
-      expect(@responder.event_regex).to match("@botsci generate pdf   \r\n")
+      expect(@responder.event_regex).to match("@botsci generate pdf   ")
+      expect(@responder.event_regex).to match("@botsci generate pdf   \r\n more")
     end
   end
 

--- a/spec/responders/hello_responder_spec.rb
+++ b/spec/responders/hello_responder_spec.rb
@@ -18,6 +18,7 @@ describe HelloResponder do
       expect(@responder.event_regex).to match("Hello @botsci!")
       expect(@responder.event_regex).to match("Hello @botsci.")
       expect(@responder.event_regex).to match("hi @botsci")
+      expect(@responder.event_regex).to match("hi @botsci \r\n you're great")
       expect(@responder.event_regex).to_not match("```Hello @botsci")
       expect(@responder.event_regex).to_not match("Hey @botsci!")
     end

--- a/spec/responders/help_responder_spec.rb
+++ b/spec/responders/help_responder_spec.rb
@@ -17,6 +17,7 @@ describe HelpResponder do
       expect(@responder.event_regex).to match("@botsci help")
       expect(@responder.event_regex).to match("@botsci help!")
       expect(@responder.event_regex).to match("@botsci help.")
+      expect(@responder.event_regex).to match("@botsci help.\r\n more")
       expect(@responder.event_regex).to_not match("```@botsci help")
     end
 

--- a/spec/responders/invite_responder_spec.rb
+++ b/spec/responders/invite_responder_spec.rb
@@ -16,7 +16,8 @@ describe InviteResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci invite @arfon")
       expect(@responder.event_regex).to match("@botsci invite @arfon.")
-      expect(@responder.event_regex).to match("@botsci invite @xuanxu  \r\n")
+      expect(@responder.event_regex).to match("@botsci invite @xuanxu  ")
+      expect(@responder.event_regex).to match("@botsci invite @xuanxu  \r\n more")
       expect(@responder.event_regex).to_not match("@botsci invite @arfon as whatever")
       expect(@responder.event_regex).to_not match("invite @buffy")
       expect(@responder.event_regex).to_not match("@botsci invite ")

--- a/spec/responders/label_command_responder_spec.rb
+++ b/spec/responders/label_command_responder_spec.rb
@@ -15,7 +15,8 @@ describe LabelCommandResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci recommend publication")
-      expect(@responder.event_regex).to match("@botsci recommend publication   \r\n")
+      expect(@responder.event_regex).to match("@botsci recommend publication   ")
+      expect(@responder.event_regex).to match("@botsci recommend publication   \r\n another comment")
       expect(@responder.event_regex).to_not match("@botsci recommend publication now")
       expect(@responder.event_regex).to_not match("@botsci recommend")
       expect(@responder.event_regex).to_not match("@botsci recommend public")

--- a/spec/responders/list_of_values_responder_spec.rb
+++ b/spec/responders/list_of_values_responder_spec.rb
@@ -15,7 +15,8 @@ describe ListOfValuesResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci add @arfon to reviewers")
-      expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  \r\n")
+      expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  ")
+      expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  \r\nmore")
       expect(@responder.event_regex).to_not match("@botsci add to reviewers")
       expect(@responder.event_regex).to_not match("@botsci remove   from reviewers")
     end

--- a/spec/responders/list_team_members_responder_spec.rb
+++ b/spec/responders/list_team_members_responder_spec.rb
@@ -17,8 +17,8 @@ describe ListTeamMembersResponder do
       expect(@responder.event_regex).to match("@botsci list editors")
       expect(@responder.event_regex).to match("@botsci list editors.")
       expect(@responder.event_regex).to match("@botsci list editors  \r\n")
+      expect(@responder.event_regex).to match("@botsci list editors  \r\n ignore this")
       expect(@responder.event_regex).to_not match("```@botsci list editors")
-      expect(@responder.event_regex).to_not match("@botsci list editors  \r\n more")
     end
   end
 

--- a/spec/responders/reminders_responder_spec.rb
+++ b/spec/responders/reminders_responder_spec.rb
@@ -16,7 +16,8 @@ describe RemindersResponder do
 
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci remind @reviewer33 in 2 weeks")
-      expect(@responder.event_regex).to match("@botsci remind @reviewer33 in 1 month    \r\n")
+      expect(@responder.event_regex).to match("@botsci remind @reviewer33 in 1 month    ")
+      expect(@responder.event_regex).to match("@botsci remind @reviewer33 in 1 month    \r\n more")
     end
   end
 

--- a/spec/responders/remove_editor_responder_spec.rb
+++ b/spec/responders/remove_editor_responder_spec.rb
@@ -16,6 +16,7 @@ describe RemoveEditorResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci remove editor")
       expect(@responder.event_regex).to match("@botsci remove editor ")
+      expect(@responder.event_regex).to match("@botsci remove editor\r\nmore")
       expect(@responder.event_regex).to_not match("@bot_name remove editor")
       expect(@responder.event_regex).to_not match("@botsci remove editor 3")
     end

--- a/spec/responders/repo_checks_responder_spec.rb
+++ b/spec/responders/repo_checks_responder_spec.rb
@@ -19,6 +19,7 @@ describe RepoChecksResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@botsci check repository")
       expect(@responder.event_regex).to match("@botsci check repository    \r\n")
+      expect(@responder.event_regex).to match("@botsci check repository\r\nmore")
       expect(@responder.event_regex).to match("@botsci check repository from branch custom-branch")
       expect(@responder.event_regex).to match("@botsci check repository from branch custom/branch")
       expect(@responder.event_regex).to match("@botsci check repository from branch development    \r\n")

--- a/spec/responders/reviewer_checklist_comment_responder_spec.rb
+++ b/spec/responders/reviewer_checklist_comment_responder_spec.rb
@@ -19,6 +19,7 @@ describe ReviewerChecklistCommentResponder do
       expect(@responder.event_regex).to match("@botsci generate my checklist")
       expect(@responder.event_regex).to match("@botsci generate my checklist.")
       expect(@responder.event_regex).to match("@botsci generate my checklist   \r\n")
+      expect(@responder.event_regex).to match("@botsci generate my checklist   \r\nmore")
       expect(@responder.event_regex).to_not match("@botsci generate my checklist for @arfon.")
       expect(@responder.event_regex).to_not match("@botsci generate my checkl")
     end

--- a/spec/responders/reviewers_list_responder_spec.rb
+++ b/spec/responders/reviewers_list_responder_spec.rb
@@ -18,7 +18,9 @@ describe ReviewersListResponder do
       expect(@responder.event_regex).to match("@botsci add @arfon as reviewer")
       expect(@responder.event_regex).to match("@botsci add me as reviewer")
       expect(@responder.event_regex).to match("@botsci remove me from reviewers")
+      expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  ")
       expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  \r\n")
+      expect(@responder.event_regex).to match("@botsci remove @arfon from reviewers  \r\n more ")
       expect(@responder.event_regex).to_not match("@botsci add to reviewers")
       expect(@responder.event_regex).to_not match("@botsci remove   from reviewers")
     end

--- a/spec/responders/set_value_responder_spec.rb
+++ b/spec/responders/set_value_responder_spec.rb
@@ -17,6 +17,7 @@ describe SetValueResponder do
       expect(@responder.event_regex).to match("@botsci set v1.0.3-beta as version")
       expect(@responder.event_regex).to match("@botsci set v1.0.3-beta as version.")
       expect(@responder.event_regex).to match("@botsci set 2.345 as version   \r\n")
+      expect(@responder.event_regex).to match("@botsci set 2.345 as version   \r\n more")
       expect(@responder.event_regex).to_not match("@botsci set v12.0 as editor")
       expect(@responder.event_regex).to_not match("@botsci set v1.0.3-beta as version now")
     end

--- a/spec/responders/thanks_responder_spec.rb
+++ b/spec/responders/thanks_responder_spec.rb
@@ -17,6 +17,7 @@ describe ThanksResponder do
       expect(@responder.event_regex).to match("@botsci thanks for that")
       expect(@responder.event_regex).to match("@botsci thank you!")
       expect(@responder.event_regex).to match("Thanks @botsci!")
+      expect(@responder.event_regex).to match("Thanks @botsci! \r\n you're awesome")
       expect(@responder.event_regex).to match("THANK YOU @botsci")
       expect(@responder.event_regex).to_not match("```@botsci thanks")
     end

--- a/spec/responders/wrong_command_responder_spec.rb
+++ b/spec/responders/wrong_command_responder_spec.rb
@@ -16,6 +16,7 @@ describe WrongCommandResponder do
     it "should define a catch-all regex" do
       expect(@responder.event_regex).to match("@botsci whatever")
       expect(@responder.event_regex).to match("@botsci reviawwers   \n")
+      expect(@responder.event_regex).to match("@botsci reviawwers   \r\n more")
       expect(@responder.event_regex).to_not match(" @botsci whatever")
       expect(@responder.event_regex).to_not match("```@botsci whatever")
     end


### PR DESCRIPTION
This PRs changes every responder to allow any text after the first line (where the command should be).