### PR TITLE
Command to update the paper repository URL

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -63,6 +63,11 @@ buffy:
           template_file: set_archive.md
       - branch:
           sample_value: "joss-paper"
+      - target-repository:
+          only: editors
+          sample_value: "https://github.com/organization/repo"
+          aliased_as: repository
+
     external_service:
       - reject:
           only: eics

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -67,7 +67,15 @@ buffy:
           only: editors
           sample_value: "https://github.com/organization/repo"
           aliased_as: repository
-
+          external_call:
+            url: "https://joss.theoj.org/papers/api_update_paper_info"
+            method: post
+            query_params:
+              secret: <%= ENV['JOSS_SECRET'] %>
+            mapping:
+              id: issue_id
+              repository_url: new_value
+            silent: true
     external_service:
       - reject:
           only: eics


### PR DESCRIPTION
This PR adds the configuration to have a `set <new-url> as repository` command.
As described here: https://github.com/openjournals/joss/issues/1095
The documentation for this command is updated in this other PR over the JOSS repo: https://github.com/openjournals/joss/pull/1108