### PR TITLE
Add command for editors to create a post-review checklist

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -227,6 +227,15 @@ buffy:
           command: list reviewers
           description: Get a link to the complete list of reviewers
           template_file: reviewers_list.md
+    update_comment:
+      - editor_post-review_checklist:
+          only: editors
+          if:
+            title: "^\\[REVIEW\\]:"
+            reject_msg: "This is not a review issue"
+          command: create post-review checklist
+          description: Creates a post-review checklist with editor and authors tasks
+          template_file: post-review_checklist.md
     welcome:
       - pre_review_issue:
           if:


### PR DESCRIPTION
This PR adds the following command to the JOSS configuration:

`@editorialbot create post-review checklist`

allowing editors to create a pre-acceptance checklist.


Closes openjournals/joss#1188 

