### PR TITLE
Send issue_title to the draft-paper GH action

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -139,6 +139,7 @@ buffy:
             - branch
             - target-repository
             - issue_id
+            - issue_title
           mapping:
             repository_url: target-repository
       - recommend_acceptance:


### PR DESCRIPTION
This PR adds the `issue_title` to the list of params in the `draft-paper` workflow call 