### PR TITLE
Add RTD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ author = 'Arfon Smith, Juanjo Bazán & the Open Journals community'
 extensions = [
     'sphinx.ext.mathjax',
     'recommonmark',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This PR adds the now required `.readthedocs.yaml` config file to build the Sphinx docs.