### PR TITLE
Always report bibtex entries in DOI checker

### DIFF
--- a/app/lib/doi_checker.rb
+++ b/app/lib/doi_checker.rb
@@ -19,19 +19,17 @@ class DOIChecker
         # If there's no DOI present, check Crossref to see if we can find a candidate DOI for this entry.
         elsif entry.has_field?('title')
             candidate_doi = crossref_lookup(entry.title.value)
+            truncated_title = entry.title.to_s[0,50]
+            truncated_title += "..." if truncated_title.length < entry.title.to_s.length
             if candidate_doi == "CROSSREF-ERROR"
-              truncated_title = entry.title.to_s[0,50]
-              truncated_title += "..." if truncated_title.length < entry.title.to_s.length
               doi_summary[:missing].push("Errored finding suggestions for \"#{truncated_title}\", please try later")
             elsif candidate_doi
-              doi_summary[:missing].push("#{candidate_doi} may be a valid DOI for title: #{entry.title}")
+              doi_summary[:missing].push("#{candidate_doi} may be a valid DOI for title: #{truncated_title}")
             else
               doi_summary[:missing].push("No DOI given, and none found for title: #{truncated_title}")
             end
         else
-          truncated_entry = entry.to_s[0,50]
-          truncated_entry += "..." if truncated_entry.length entry.to_s.length
-          doi_summary[:missing].push("No DOI or title given for entry #{truncated_entry}")
+          doi_summary[:missing].push("Entry without DOI or title found")
         end
       end
     end

--- a/app/lib/doi_checker.rb
+++ b/app/lib/doi_checker.rb
@@ -25,7 +25,13 @@ class DOIChecker
               doi_summary[:missing].push("Errored finding suggestions for \"#{truncated_title}\", please try later")
             elsif candidate_doi
               doi_summary[:missing].push("#{candidate_doi} may be a valid DOI for title: #{entry.title}")
+            else
+              doi_summary[:missing].push("No DOI given, and none found for title: #{truncated_title}")
             end
+        else
+          truncated_entry = entry.to_s[0,50]
+          truncated_entry += "..." if truncated_entry.length entry.to_s.length
+          doi_summary[:missing].push("No DOI or title given for entry #{truncated_entry}")
         end
       end
     end

--- a/spec/doi_checker_spec.rb
+++ b/spec/doi_checker_spec.rb
@@ -102,8 +102,8 @@ describe DOIChecker do
 
       doi_summary = doi_checker.check_dois
       expect(doi_summary[:ok]).to be_empty
-      expect(doi_summary[invalid]).to be_empty
-      expect(doi_summary[:missing][0]).to eq("No DOI or title given for entry #{entry.to_s}")
+      expect(doi_summary[:invalid]).to be_empty
+      expect(doi_summary[:missing][0]).to eq("Entry without DOI or title found")
     end
   end
 

--- a/spec/doi_checker_spec.rb
+++ b/spec/doi_checker_spec.rb
@@ -82,8 +82,9 @@ describe DOIChecker do
       expect(doi_summary[:missing][0]).to eq("Errored finding suggestions for \"#{expected_title}\", please try later")
     end
 
-    it "should ignore entries no DOI and no crossref alternative" do
-      missing_doi = BibTeX::Entry.new({title: "No DOI"})
+    it "should report entries with no DOI and no crossref alternative as missing DOIs" do
+      title = "No DOI"
+      missing_doi = BibTeX::Entry.new({title: title})
       doi_checker = DOIChecker.new([missing_doi])
 
       expect(doi_checker).to receive(:crossref_lookup).with("No DOI").and_return(nil)
@@ -92,7 +93,17 @@ describe DOIChecker do
 
       expect(doi_summary[:ok]).to be_empty
       expect(doi_summary[:invalid]).to be_empty
-      expect(doi_summary[:missing]).to be_empty
+      expect(doi_summary[:missing][0]).to eq("No DOI given, and none found for title: #{title}")
+    end
+
+    it "should report entries with no DOI or title as missing both" do
+      entry = BibTex::Entry.new(journal: "A Well Respected Journal")
+      doi_checker = DOIChecker.new([entry])
+
+      doi_summary = doi_checker.check_dois
+      expect(doi_summary[:ok]).to be_empty
+      expect(doi_summary[invalid]).to be_empty
+      expect(doi_summary[:missing][0]).to eq("No DOI or title given for entry #{entry.to_s}")
     end
   end
 

--- a/spec/doi_checker_spec.rb
+++ b/spec/doi_checker_spec.rb
@@ -97,7 +97,7 @@ describe DOIChecker do
     end
 
     it "should report entries with no DOI or title as missing both" do
-      entry = BibTex::Entry.new(journal: "A Well Respected Journal")
+      entry = BibTeX::Entry.new(journal: "A Well Respected Journal")
       doi_checker = DOIChecker.new([entry])
 
       doi_summary = doi_checker.check_dois


### PR DESCRIPTION
Not all bibliography entries have DOIs, and that's fine! But it can be confusing when there are bibliography entries and they don't show up in the DOI checker - what happened to them? It is semantically correct to say that DOIs are "missing" for entries where a DOI is not provided and one can't be found when querying crossref, and also for entries where a title is not provided, both of which are currently silently dropped by the DOI checker. 

This PR adds `else` statements to the two unfinished legs of the `check_dois` method and updates the spec to match. Not sure if i wrote those test cases correctly, my bad if not.