### PR TITLE
Remove Node & Gitinspector dependencies

### DIFF
--- a/app/lib/utilities.rb
+++ b/app/lib/utilities.rb
@@ -23,9 +23,4 @@ module Utilities
     status.success? ? result : nil
   end
 
-  def run_gitinspector(local_path)
-    result, stderr, status = Open3.capture3("PYTHONIOENCODING=utf-8 gitinspector -f** #{local_path}")
-    status.success? ? result : nil
-  end
-
 end

--- a/app/workers/repo_checks_worker.rb
+++ b/app/workers/repo_checks_worker.rb
@@ -30,20 +30,13 @@ class RepoChecksWorker < BuffyWorker
     message = "```\nSoftware report:\n"
 
     cloc_result = run_cloc(path)
-    gitinspector_result = run_gitinspector(path)
 
     if cloc_result
       message << "#{cloc_result}"
     else
       message << "cloc failed to run analysis of the source code"
     end
-    message << "\n\n"
 
-    if gitinspector_result
-      message << "#{gitinspector_result}"
-    else
-      message << "gitinspector failed to run statistical information for the repository"
-    end
     message << "\n```"
 
     respond(message)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,6 @@ This will be the "user" responding to the commands issued from a reviews reposit
 Some applications and services must be available to use by Buffy:
 
 - **[Redis](https://redis.io/)**: To process background jobs Buffy needs `redis` installed.
-- **[Gitinspector](https://github.com/ejwa/gitinspector)**: The *Respository Checks Responder* performs a statistical analysis using it.
 - **[cloc](https://github.com/AlDanial/cloc)**: The *Respository Checks Responder* can analyze source code, to run this check `cloc` is used.
 
 #### Deployment
@@ -47,7 +46,6 @@ As an example, we will use [Heroku](https://www.heroku.com) to deploy Buffy. How
 
 - To process background jobs, Buffy needs a `redis` add-on, such as Heroku Redis or RedisGreen etc.
 - You can use [this Heroku buildpack](https://github.com/openjournals/heroku-buildpack-cloc) to install the `cloc` dependency.
-- You can install Gitinspector using npm by following the instructions [here](https://www.npmjs.com/package/gitinspector). If you plan to deploy to Heroku, you can add the `heroku/nodejs` buildpack to your app.
 
 **2.** In the app settings add the following Config Vars:
 

--- a/docs/responders/repo_checks.md
+++ b/docs/responders/repo_checks.md
@@ -39,7 +39,7 @@ The body of the issue should have the url of the repository marked with HTML com
 
 The following values are valid for the `:checks` list:
 
-* `repo summary`: This check performs an analysis of the source code and list authorship, contributions and file types information.
+* `repo summary`: This check performs an analysis of the source code and list file types information.
 * `languages`: This will detect the languages used in the repository and tagged the issue with the top three used languages.
 * `wordcount`: This will count the number of words in the paper file.
 * `license`: This will look for an Open Source License in the target repo and reply an error message if no license is found.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "buffy-dependencies",
-  "description": "Some dependencies to install on deployment",
-  "scripts": {
-    "preinstall": "npm install -g gitinspector"
-  },
-  "author": "Juanjo Bazán",
-  "license": "MIT"
-}

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -81,22 +81,4 @@ describe "Utilities" do
     end
   end
 
-  describe "#run_gitinspector" do
-    it "should run cloc return true" do
-      expect(Open3).to receive(:capture3).
-                       with("PYTHONIOENCODING=utf-8 gitinspector -f** tmp/543/repo").
-                       and_return(["OK", "", OpenStruct.new(success?: true)])
-
-      expect(subject.run_gitinspector("tmp/543/repo")).to be_truthy
-    end
-
-    it "should return nil if command fails" do
-      expect(Open3).to receive(:capture3).
-                       with("PYTHONIOENCODING=utf-8 gitinspector -f** tmp/543/repo").
-                       and_return(["", "stats failed", OpenStruct.new(success?: false)])
-
-      expect(subject.run_gitinspector("tmp/543/repo")).to be_falsy
-    end
-  end
-
 end

--- a/spec/workers/repo_checks_worker_spec.rb
+++ b/spec/workers/repo_checks_worker_spec.rb
@@ -43,7 +43,6 @@ describe RepoChecksWorker do
   describe "#repo_summary" do
     before do
       allow(@worker).to receive(:run_cloc).and_return("Ruby 50%, Julia 50%")
-      allow(@worker).to receive(:run_gitinspector).and_return("Author: Buffy Summers")
     end
 
     it "should include cloc report" do
@@ -51,20 +50,9 @@ describe RepoChecksWorker do
       @worker.repo_summary
     end
 
-    it "should include gitinspector report" do
-      expect(@worker).to receive(:respond).with(/Author: Buffy Summers/)
-      @worker.repo_summary
-    end
-
     it "should include error message if cloc fails" do
       expect(@worker).to receive(:run_cloc).and_return(nil)
       expect(@worker).to receive(:respond).with(/cloc failed to run/)
-      @worker.repo_summary
-    end
-
-    it "should include gitinspector report" do
-      expect(@worker).to receive(:run_gitinspector).and_return(nil)
-      expect(@worker).to receive(:respond).with(/gitinspector failed to run/)
       @worker.repo_summary
     end
   end


### PR DESCRIPTION
The prefered way to run a git analysis on the submitted code is using [a GitHub action](https://github.com/openjournals/gh-action-repo-checks).
This PR removes Gitinspector from the dependencies and also node as it is not loger needed.