### PR TITLE
Special case `10.5555` DOIs (and fix ambiguous DOI checker results)

### DIFF
--- a/app/lib/doi_checker.rb
+++ b/app/lib/doi_checker.rb
@@ -9,32 +9,52 @@ class DOIChecker
   end
 
   def check_dois
-    doi_summary = {ok: [], missing: [], invalid: []}
+    doi_summary = {ok: [], skip: [], missing: [], invalid: []}
 
     if @entries.any?
       @entries.each do |entry|
-        if entry.has_field?('doi') && !entry.doi.empty?
+        # handle special cases first
+        special_case = self.handle_special_case(entry)
+        if special_case
+          doi_validity = special_case
+        elsif entry.has_field?('doi') && !entry.doi.empty?
+          # Validate entries with DOIs
           doi_validity = validate_doi(entry.doi.value)
-          doi_summary[doi_validity[:validity]].push(doi_validity[:msg])
-        # If there's no DOI present, check Crossref to see if we can find a candidate DOI for this entry.
         elsif entry.has_field?('title')
-            candidate_doi = crossref_lookup(entry.title.value)
-            truncated_title = entry.title.to_s[0,50]
-            truncated_title += "..." if truncated_title.length < entry.title.to_s.length
-            if candidate_doi == "CROSSREF-ERROR"
-              doi_summary[:missing].push("Errored finding suggestions for \"#{truncated_title}\", please try later")
-            elsif candidate_doi
-              doi_summary[:missing].push("#{candidate_doi} may be a valid DOI for title: #{truncated_title}")
-            else
-              doi_summary[:missing].push("No DOI given, and none found for title: #{truncated_title}")
-            end
+          # Try and find candidate entries if doi absent, but title present
+          doi_validity = handle_missing_doi(entry)
         else
-          doi_summary[:missing].push("Entry without DOI or title found")
+          doi_validity = {validity: :missing, msg: "Entry without DOI or title found"}
         end
+
+        doi_summary[doi_validity[:validity]].push(doi_validity[:msg])
       end
     end
 
     doi_summary
+    end
+
+  # any special case should return false if not applicable, and an object like
+  # {:validity => :ok, :msg => "whatever"} otherwise.
+  # Add additional special cases as private methods and chain in a tidy sequence plz <3
+  def handle_special_case(entry)
+    validity = acm_105555_prefix(entry) and return validity
+    false
+  end
+
+
+  # If there's no DOI present, check Crossref to see if we can find a candidate DOI for this entry.
+  def handle_missing_doi(entry)
+    candidate_doi = crossref_lookup(entry.title.value)
+    truncated_title = entry.title.to_s[0,50]
+    truncated_title += "..." if truncated_title.length < entry.title.to_s.length
+    if candidate_doi == "CROSSREF-ERROR"
+      { validity: :missing, msg: "Errored finding suggestions for \"#{truncated_title}\", please try later" }
+    elsif candidate_doi
+      { validity: :missing, msg: "#{candidate_doi} may be a valid DOI for title: #{truncated_title}" }
+    else
+      { validity: :skip, msg: "No DOI given, and none found for title: #{truncated_title}" }
+    end
   end
 
   def validate_doi(doi_string)
@@ -111,5 +131,17 @@ class DOIChecker
 
   def similar?(string_1, string_2)
     levenshtein_distance(string_1, string_2) < 3
+  end
+
+  private
+
+  def acm_105555_prefix(entry)
+    if entry.has_field?('doi') && entry.doi.include?("10.5555/")
+      { validity: :invalid, msg: "#{entry.doi} is INVALID - 10.5555 is a known broken prefix, replace with https://dl.acm.org/doi/{doi} in the {url} field" }
+    elsif entry.has_field?('url') && entry.url.include?("https://dl.acm.org/doi/10.5555")
+      { validity: :skip, msg: "#{entry.url} - correctly put 10.5555 prefixed doi in the url field, editor should ensure this resolves" }
+    else
+      false
+    end
   end
 end

--- a/app/responses/doi_checks.erb
+++ b/app/responses/doi_checks.erb
@@ -1,9 +1,13 @@
 ```
 Reference check summary (note 'MISSING' DOIs are suggestions that need verification):
 <% doi_summary.each do |type, messages| -%>
-
-<%= type.to_s.upcase %> DOIs
-
+<% if type.to_s === "ok" %>
+✅ - <%= type.to_s.upcase %> DOIs
+<% elsif type.to_s === "skip" %>
+❔ - <%= type.to_s.upcase %> DOIs
+<% else %>
+❌ - <%= type.to_s.upcase %> DOIs
+<% end %>
 <%  if messages.empty? -%>
 - None
 <%  else -%>


### PR DESCRIPTION
There's a recurring issue where the DOI checker flags "10.5555" prefixed DOIs as missing with the ambiguous message I left in https://github.com/openjournals/buffy/pull/101 (my bad). Those DOIs are known to not resolve. 

This PR special-cases `10.5555` prefixed DOIs such that 
- if they are present in the `{doi}` field they are marked as invalid with a prompt to include it in the `{url}` field instead
- If they are present in the `{url}` field they are marked as `:skip` with a note for the editor to confirm they resolve - I tried testing the resolution, but unhelpfully the website seems to respond with a `200` code and display a `404` page......

To do that, I 
- moved the body of the checker to a `handle_missing_doi` method
- made a `handle_special_case` method to allow for future special cases, if any

I also fixed the ambiguous message by adding a `skip` type that is "maybe ok, editor take a look" field and made the template render categories with emoji that indicate the status of each DOI, it looks like...

```
Reference check summary (note 'MISSING' DOIs are suggestions that need verification):

✅ - OK DOIs

- this value is ok
- another ok value

❔ - SKIP DOIs

- this value is skipped but may still be ok
- https://dl.acm.org/doi/10.5555/xxxx.yyyy  - correctly put 10.5555 prefixed doi in the url field, editor should ensure this resolves

❌ - MISSING DOIs

- this one needs a doi
- so does this one

❌ - INVALID DOIs

- 10.5555/xxxx.yyyy is INVALID - 10.5555 is a known broken prefix, replace with https://dl.acm.org/doi/{doi} in the {url} field"
```

My ruby is bad, so someone else please check my work here!