### PR TITLE
Add undocumented synonym

### DIFF
--- a/app/responders/add_and_remove_assignee_responder.rb
+++ b/app/responders/add_and_remove_assignee_responder.rb
@@ -13,7 +13,7 @@ class AddAndRemoveAssigneeResponder < Responder
     add_or_remove = @match_data[1].downcase
     user = @match_data[2]
 
-    if add_or_remove == "add"
+    iif ["add", "assign"].include?(add_or_remove)
       add user
     elsif add_or_remove == "remove"
       remove user

--- a/app/responders/add_and_remove_assignee_responder.rb
+++ b/app/responders/add_and_remove_assignee_responder.rb
@@ -13,7 +13,7 @@ class AddAndRemoveAssigneeResponder < Responder
     add_or_remove = @match_data[1].downcase
     user = @match_data[2]
 
-    iif ["add", "assign"].include?(add_or_remove)
+    if ["add", "assign"].include?(add_or_remove)
       add user
     elsif add_or_remove == "remove"
       remove user


### PR DESCRIPTION
I got annoyed recently that you assign editors, but you have to add reviewers. In my head, assigning and adding are the same thing. 

I want a way where you can also assign a reviewer, without having to type another command. This adds that possibility, but it doesn't enforce it for others by documenting or showing it as an option - which might be a good idea. Instead, it just will fall back on adding the user if someone mistakenly uses the word 'assign'.